### PR TITLE
[codex] Harmoniser les cartes propriétaire et ajouter AWAITING_TENANT_FORM

### DIFF
--- a/app/api/stripe/create-payment-intent/route.ts
+++ b/app/api/stripe/create-payment-intent/route.ts
@@ -48,11 +48,17 @@ export async function POST(req: NextRequest) {
         const existing = await stripe.paymentIntents.retrieve(
           intakeLink.stripePaymentIntentId
         );
-        if (
-          existing.status !== "succeeded" &&
-          existing.status !== "canceled"
-        ) {
-          // Mettre à jour le receipt_email s'il manque
+        if (existing.status === "succeeded") {
+          // Le paiement a déjà réussi — ne PAS créer un nouveau PI
+          // Retourner l'ID existant pour que le client puisse poursuivre la soumission
+          return NextResponse.json({
+            clientSecret: existing.client_secret,
+            alreadyPaid: true,
+            paymentIntentId: existing.id,
+          });
+        }
+        if (existing.status !== "canceled") {
+          // PI en cours (requires_payment_method, requires_confirmation, etc.) — réutiliser
           if (clientEmail && !existing.receipt_email) {
             await stripe.paymentIntents.update(intakeLink.stripePaymentIntentId, {
               receipt_email: clientEmail,

--- a/app/client/(protected)/locataire/baux/[id]/page.tsx
+++ b/app/client/(protected)/locataire/baux/[id]/page.tsx
@@ -17,6 +17,7 @@ export const fetchCache = "force-no-store";
 const statusLabels: Record<BailStatus, string> = {
   DRAFT: "Brouillon",
   AWAITING_TENANT: "En attente du locataire",
+  AWAITING_TENANT_FORM: "En attente du formulaire locataire",
   PENDING_VALIDATION: "En attente de validation",
   READY_FOR_NOTARY: "Prêt pour notaire",
   CLIENT_CONTACTED: "Client contacté",
@@ -28,8 +29,9 @@ const statusLabels: Record<BailStatus, string> = {
 
 const statusColors: Record<BailStatus, string> = {
   DRAFT: "bg-gray-100 text-gray-800",
-  AWAITING_TENANT: "bg-orange-100 text-orange-800",
-  PENDING_VALIDATION: "bg-orange-100 text-orange-800",
+  AWAITING_TENANT: "bg-violet-100 text-violet-800",
+  AWAITING_TENANT_FORM: "bg-indigo-100 text-indigo-800",
+  PENDING_VALIDATION: "bg-amber-100 text-amber-800",
   READY_FOR_NOTARY: "bg-blue-100 text-blue-800",
   CLIENT_CONTACTED: "bg-purple-100 text-purple-800",
   SIGNED: "bg-green-100 text-green-800",

--- a/components/client/bail-detail-drawer.tsx
+++ b/components/client/bail-detail-drawer.tsx
@@ -24,6 +24,7 @@ import { Loader2 } from "lucide-react";
 const statusLabels: Record<BailStatus, string> = {
   DRAFT: "Brouillon",
   AWAITING_TENANT: "En attente du locataire",
+  AWAITING_TENANT_FORM: "En attente du formulaire locataire",
   PENDING_VALIDATION: "En cours de validation",
   READY_FOR_NOTARY: "Prêt pour notaire",
   CLIENT_CONTACTED: "Client contacté",
@@ -35,8 +36,9 @@ const statusLabels: Record<BailStatus, string> = {
 
 const statusColors: Record<BailStatus, string> = {
   DRAFT: "bg-gray-100 text-gray-800 border-gray-200 text-xs",
-  AWAITING_TENANT: "bg-orange-100 text-orange-800 border-orange-200 text-xs",
-  PENDING_VALIDATION: "bg-orange-100 text-orange-800 border-orange-200 text-xs",
+  AWAITING_TENANT: "bg-violet-100 text-violet-800 border-violet-200 text-xs",
+  AWAITING_TENANT_FORM: "bg-indigo-100 text-indigo-800 border-indigo-200 text-xs",
+  PENDING_VALIDATION: "bg-amber-100 text-amber-800 border-amber-200 text-xs",
   READY_FOR_NOTARY: "bg-blue-100 text-blue-800 border-blue-200 text-xs",
   CLIENT_CONTACTED: "bg-purple-100 text-purple-800 border-purple-200 text-xs",
   SIGNED: "bg-green-100 text-green-800 border-green-200 text-xs",

--- a/components/client/bails-list-with-filter.tsx
+++ b/components/client/bails-list-with-filter.tsx
@@ -56,6 +56,7 @@ type FilterType = "all" | "completed";
 const statusLabels: Record<BailStatus, string> = {
   DRAFT: "Brouillon",
   AWAITING_TENANT: "En attente du locataire",
+  AWAITING_TENANT_FORM: "En attente du formulaire locataire",
   PENDING_VALIDATION: "En attente de validation",
   READY_FOR_NOTARY: "Prêt pour notaire",
   CLIENT_CONTACTED: "Client contacté",
@@ -67,8 +68,9 @@ const statusLabels: Record<BailStatus, string> = {
 
 const statusColors: Record<BailStatus, string> = {
   DRAFT: "bg-gray-100 text-gray-800",
-  AWAITING_TENANT: "bg-orange-100 text-orange-800",
-  PENDING_VALIDATION: "bg-orange-100 text-orange-800",
+  AWAITING_TENANT: "bg-violet-100 text-violet-800",
+  AWAITING_TENANT_FORM: "bg-indigo-100 text-indigo-800",
+  PENDING_VALIDATION: "bg-amber-100 text-amber-800",
   READY_FOR_NOTARY: "bg-blue-100 text-blue-800",
   CLIENT_CONTACTED: "bg-purple-100 text-purple-800",
   SIGNED: "bg-green-100 text-green-800",

--- a/components/client/dashboard-locataire-client.tsx
+++ b/components/client/dashboard-locataire-client.tsx
@@ -248,7 +248,6 @@ function BailCard({ bail }: { bail: Bail }) {
           <div className="flex flex-wrap gap-1.5">
             {bail.rentAmount != null && bail.rentAmount > 0 && (
               <span className="inline-flex items-center gap-1 text-xs font-semibold bg-primary/10 text-primary rounded-full px-2.5 py-1">
-                <Euro className="h-3 w-3" />
                 {bail.rentAmount.toLocaleString()} €/mois
               </span>
             )}

--- a/components/client/dashboard-locataire-client.tsx
+++ b/components/client/dashboard-locataire-client.tsx
@@ -246,7 +246,7 @@ function BailCard({ bail }: { bail: Bail }) {
 
           {/* Chips */}
           <div className="flex flex-wrap gap-1.5">
-            {bail.rentAmount && (
+            {bail.rentAmount != null && bail.rentAmount > 0 && (
               <span className="inline-flex items-center gap-1 text-xs font-semibold bg-primary/10 text-primary rounded-full px-2.5 py-1">
                 <Euro className="h-3 w-3" />
                 {bail.rentAmount.toLocaleString()} €/mois

--- a/components/client/dashboard-locataire-client.tsx
+++ b/components/client/dashboard-locataire-client.tsx
@@ -102,6 +102,7 @@ const BAIL_STEPS = [
 const BAIL_STEP_INDEX: Record<string, number> = {
   DRAFT: 0,
   AWAITING_TENANT: 0,
+  AWAITING_TENANT_FORM: 0,
   PENDING_VALIDATION: 0,
   READY_FOR_NOTARY: 1,
   CLIENT_CONTACTED: 1,
@@ -112,6 +113,7 @@ const BAIL_STEP_INDEX: Record<string, number> = {
 const BAIL_STATUS_CONFIG: Record<string, { badgeBg: string; label: string; icon: React.ElementType }> = {
   DRAFT: { badgeBg: "bg-blue-50 text-blue-700 border-blue-200", label: "En vérification", icon: Clock },
   AWAITING_TENANT: { badgeBg: "bg-orange-50 text-orange-700 border-orange-200", label: "En attente", icon: Clock },
+  AWAITING_TENANT_FORM: { badgeBg: "bg-indigo-50 text-indigo-700 border-indigo-200", label: "Formulaire à compléter", icon: FileText },
   PENDING_VALIDATION: { badgeBg: "bg-blue-50 text-blue-700 border-blue-200", label: "En vérification", icon: Clock },
   READY_FOR_NOTARY: { badgeBg: "bg-violet-50 text-violet-700 border-violet-200", label: "Chez le notaire", icon: Scale },
   CLIENT_CONTACTED: { badgeBg: "bg-violet-50 text-violet-700 border-violet-200", label: "Chez le notaire", icon: Scale },
@@ -138,7 +140,7 @@ const STAGE_LABELS: Record<string, string> = {
   finalize: "Documents",
 };
 
-const ACTIVE_STATUSES = ["DRAFT", "PENDING_VALIDATION", "READY_FOR_NOTARY", "CLIENT_CONTACTED"];
+const ACTIVE_STATUSES = ["DRAFT", "AWAITING_TENANT_FORM", "PENDING_VALIDATION", "READY_FOR_NOTARY", "CLIENT_CONTACTED"];
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -397,10 +399,10 @@ export function DashboardLocataireClient({
   const intakeBailIds = new Set([activeIntake?.bailId].filter(Boolean));
 
   const awaitingBails = baux.filter(
-    (b) => b.status === "AWAITING_TENANT" || intakeBailIds.has(b.id)
+    (b) => b.status === "AWAITING_TENANT" || b.status === "AWAITING_TENANT_FORM" || intakeBailIds.has(b.id)
   );
   const activeBails = baux.filter(
-    (b) => b.status !== "AWAITING_TENANT" && !intakeBailIds.has(b.id)
+    (b) => b.status !== "AWAITING_TENANT" && b.status !== "AWAITING_TENANT_FORM" && !intakeBailIds.has(b.id)
   );
 
   const enCours = activeBails.filter((b) => ACTIVE_STATUSES.includes(b.status)).length;
@@ -411,7 +413,7 @@ export function DashboardLocataireClient({
   const recentBails = [...activeBails]
     .sort((a, b) => {
       const p = (s: string) =>
-        s === "CLIENT_CONTACTED" ? 0 : s === "PENDING_VALIDATION" ? 1 : s === "READY_FOR_NOTARY" ? 2 : s === "DRAFT" ? 3 : s === "SIGNED" ? 4 : 5;
+        s === "CLIENT_CONTACTED" ? 0 : s === "AWAITING_TENANT_FORM" ? 1 : s === "PENDING_VALIDATION" ? 2 : s === "READY_FOR_NOTARY" ? 3 : s === "DRAFT" ? 4 : s === "SIGNED" ? 5 : 6;
       return p(a.status) - p(b.status);
     })
     .slice(0, 4);

--- a/components/client/dashboard-proprietaire-client.tsx
+++ b/components/client/dashboard-proprietaire-client.tsx
@@ -150,7 +150,7 @@ const STEP_INDEX: Record<string, number> = {
 const STATUS_INFO: Record<string, { message: string; needsAction?: boolean }> = {
   DRAFT: { message: "Votre dossier est entre nos mains. On revient vers vous sous 48h." },
   AWAITING_TENANT: { message: "En attente du locataire — ajoutez son email pour débloquer le dossier.", needsAction: true },
-  AWAITING_TENANT_FORM: { message: "En attente du formulaire de votre locataire. Il recevra un lien par email." },
+  AWAITING_TENANT_FORM: { message: "En attente des informations du locataire. Le lien lui a bien été envoyé par email." },
   PENDING_VALIDATION: { message: "Votre dossier est entre nos mains. On revient vers vous sous 48h." },
   READY_FOR_NOTARY: { message: "Un notaire a pris en charge votre dossier. Il va vous contacter prochainement." },
   CLIENT_CONTACTED: { message: "Votre notaire vous a contacté — répondez-lui pour fixer la date de signature.", needsAction: true },

--- a/components/client/dashboard-proprietaire-client.tsx
+++ b/components/client/dashboard-proprietaire-client.tsx
@@ -139,6 +139,7 @@ const STEPS = [
 const STEP_INDEX: Record<string, number> = {
   DRAFT: 0,
   AWAITING_TENANT: 0,
+  AWAITING_TENANT_FORM: 0,
   PENDING_VALIDATION: 0,
   READY_FOR_NOTARY: 1,
   CLIENT_CONTACTED: 1,
@@ -149,6 +150,7 @@ const STEP_INDEX: Record<string, number> = {
 const STATUS_INFO: Record<string, { message: string; needsAction?: boolean }> = {
   DRAFT: { message: "Votre dossier est entre nos mains. On revient vers vous sous 48h." },
   AWAITING_TENANT: { message: "En attente du locataire — ajoutez son email pour débloquer le dossier.", needsAction: true },
+  AWAITING_TENANT_FORM: { message: "En attente du formulaire de votre locataire. Il recevra un lien par email." },
   PENDING_VALIDATION: { message: "Votre dossier est entre nos mains. On revient vers vous sous 48h." },
   READY_FOR_NOTARY: { message: "Un notaire a pris en charge votre dossier. Il va vous contacter prochainement." },
   CLIENT_CONTACTED: { message: "Votre notaire vous a contacté — répondez-lui pour fixer la date de signature.", needsAction: true },
@@ -170,7 +172,7 @@ const STAGE_LABELS: Record<string, string> = {
   finalize: "Documents",
 };
 
-const ACTIVE_STATUSES = ["DRAFT", "AWAITING_TENANT", "PENDING_VALIDATION", "READY_FOR_NOTARY", "CLIENT_CONTACTED"];
+const ACTIVE_STATUSES = ["DRAFT", "AWAITING_TENANT", "AWAITING_TENANT_FORM", "PENDING_VALIDATION", "READY_FOR_NOTARY", "CLIENT_CONTACTED"];
 
 const STATUS_CONFIG: Record<string, {
   borderColor: string;
@@ -189,6 +191,12 @@ const STATUS_CONFIG: Record<string, {
     badgeBg: "bg-orange-50 text-orange-700 border-orange-200 dark:bg-orange-950/50 dark:text-orange-300 dark:border-orange-800",
     label: "Locataire manquant",
     icon: UserPlus,
+  },
+  AWAITING_TENANT_FORM: {
+    borderColor: "border-l-indigo-400",
+    badgeBg: "bg-indigo-50 text-indigo-700 border-indigo-200 dark:bg-indigo-950/50 dark:text-indigo-300 dark:border-indigo-800",
+    label: "Formulaire locataire en attente",
+    icon: Clock,
   },
   PENDING_VALIDATION: {
     borderColor: "border-l-blue-400",
@@ -682,7 +690,7 @@ export function DashboardProprietaireClient({
   const recentBails = [...baux]
     .sort((a, b) => {
       const p = (s: string) =>
-        s === "CLIENT_CONTACTED" ? 0 : s === "PENDING_VALIDATION" ? 1 : s === "READY_FOR_NOTARY" ? 2 : s === "AWAITING_TENANT" ? 3 : s === "DRAFT" ? 4 : s === "SIGNED" ? 5 : 6;
+        s === "CLIENT_CONTACTED" ? 0 : s === "AWAITING_TENANT_FORM" ? 1 : s === "PENDING_VALIDATION" ? 2 : s === "READY_FOR_NOTARY" ? 3 : s === "AWAITING_TENANT" ? 4 : s === "DRAFT" ? 5 : s === "SIGNED" ? 6 : 7;
       return p(a.status) - p(b.status);
     })
     .slice(0, 4);

--- a/components/client/dashboard-proprietaire-client.tsx
+++ b/components/client/dashboard-proprietaire-client.tsx
@@ -1,53 +1,16 @@
 "use client";
 
-import { useState, useRef } from "react";
+import { useState } from "react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import {
-  Clock,
-  AlertCircle,
-  Trophy,
-  CheckCircle2,
-  ChevronRight,
-  Plus,
-  FileText,
-  User,
-  UserPlus,
-  Sparkles,
-  ClipboardList,
-  MessageSquare,
-  Trash2,
-  Loader2,
-  MoreHorizontal,
-  ExternalLink,
-  Scale,
-  ArrowRight,
-} from "lucide-react";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  DialogDescription,
-  DialogFooter,
-} from "@/components/ui/dialog";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
+import { AlertCircle, ChevronRight, Plus, FileText, MessageSquare } from "lucide-react";
 import Link from "next/link";
 import { cn } from "@/lib/utils";
-import { ProfilType, BailType, IntakeTarget } from "@prisma/client";
-import { formatDate } from "@/lib/utils/formatters";
-import { deleteBailDraft, createTenantForLease } from "@/lib/actions/leases";
+import { IntakeTarget } from "@prisma/client";
+import { deleteBailDraft } from "@/lib/actions/leases";
 import { toast } from "sonner";
-import { useRouter } from "next/navigation";
-import { BailChatSheet } from "@/components/client/bail-chat-sheet";
+import { OwnerBailCard } from "@/components/client/owner-bail-card";
+import { OwnerProgressCard } from "@/components/client/owner-progress-card";
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -130,34 +93,6 @@ interface DashboardProprietaireClientProps {
 
 // ─── Constantes ──────────────────────────────────────────────────────────────
 
-const STEPS = [
-  { key: "PENDING_VALIDATION", shortLabel: "Vérification" },
-  { key: "READY_FOR_NOTARY", shortLabel: "Notaire" },
-  { key: "SIGNED", shortLabel: "Signé" },
-] as const;
-
-const STEP_INDEX: Record<string, number> = {
-  DRAFT: 0,
-  AWAITING_TENANT: 0,
-  AWAITING_TENANT_FORM: 0,
-  PENDING_VALIDATION: 0,
-  READY_FOR_NOTARY: 1,
-  CLIENT_CONTACTED: 1,
-  SIGNED: 2,
-  TERMINATED: 3,
-};
-
-const STATUS_INFO: Record<string, { message: string; needsAction?: boolean }> = {
-  DRAFT: { message: "Votre dossier est entre nos mains. On revient vers vous sous 48h." },
-  AWAITING_TENANT: { message: "En attente du locataire — ajoutez son email pour débloquer le dossier.", needsAction: true },
-  AWAITING_TENANT_FORM: { message: "En attente des informations du locataire. Le lien lui a bien été envoyé par email." },
-  PENDING_VALIDATION: { message: "Votre dossier est entre nos mains. On revient vers vous sous 48h." },
-  READY_FOR_NOTARY: { message: "Un notaire a pris en charge votre dossier. Il va vous contacter prochainement." },
-  CLIENT_CONTACTED: { message: "Votre notaire vous a contacté — répondez-lui pour fixer la date de signature.", needsAction: true },
-  SIGNED: { message: "Félicitations ! Votre bail a été signé avec succès." },
-  TERMINATED: { message: "Ce bail est terminé." },
-};
-
 const BAIL_TYPE_LABELS: Record<string, string> = {
   BAIL_NU_3_ANS: "Bail nu 3 ans",
   BAIL_NU_6_ANS: "Bail nu 6 ans",
@@ -174,409 +109,18 @@ const STAGE_LABELS: Record<string, string> = {
 
 const ACTIVE_STATUSES = ["DRAFT", "AWAITING_TENANT", "AWAITING_TENANT_FORM", "PENDING_VALIDATION", "READY_FOR_NOTARY", "CLIENT_CONTACTED"];
 
-const STATUS_CONFIG: Record<string, {
-  borderColor: string;
-  badgeBg: string;
-  label: string;
-  icon: React.ElementType;
-}> = {
-  DRAFT: {
-    borderColor: "border-l-blue-400",
-    badgeBg: "bg-blue-50 text-blue-700 border-blue-200 dark:bg-blue-950/50 dark:text-blue-300 dark:border-blue-800",
-    label: "En vérification",
-    icon: Clock,
-  },
-  AWAITING_TENANT: {
-    borderColor: "border-l-orange-400",
-    badgeBg: "bg-orange-50 text-orange-700 border-orange-200 dark:bg-orange-950/50 dark:text-orange-300 dark:border-orange-800",
-    label: "Locataire manquant",
-    icon: UserPlus,
-  },
-  AWAITING_TENANT_FORM: {
-    borderColor: "border-l-indigo-400",
-    badgeBg: "bg-indigo-50 text-indigo-700 border-indigo-200 dark:bg-indigo-950/50 dark:text-indigo-300 dark:border-indigo-800",
-    label: "Formulaire locataire en attente",
-    icon: Clock,
-  },
-  PENDING_VALIDATION: {
-    borderColor: "border-l-blue-400",
-    badgeBg: "bg-blue-50 text-blue-700 border-blue-200 dark:bg-blue-950/50 dark:text-blue-300 dark:border-blue-800",
-    label: "En vérification",
-    icon: Clock,
-  },
-  READY_FOR_NOTARY: {
-    borderColor: "border-l-violet-400",
-    badgeBg: "bg-violet-50 text-violet-700 border-violet-200 dark:bg-violet-950/50 dark:text-violet-300 dark:border-violet-800",
-    label: "Chez le notaire",
-    icon: Scale,
-  },
-  CLIENT_CONTACTED: {
-    borderColor: "border-l-amber-400",
-    badgeBg: "bg-amber-50 text-amber-700 border-amber-200 dark:bg-amber-950/50 dark:text-amber-300 dark:border-amber-800",
-    label: "Action requise",
-    icon: AlertCircle,
-  },
-  SIGNED: {
-    borderColor: "border-l-green-400",
-    badgeBg: "bg-green-50 text-green-700 border-green-200 dark:bg-green-950/50 dark:text-green-300 dark:border-green-800",
-    label: "Signé",
-    icon: CheckCircle2,
-  },
-  TERMINATED: {
-    borderColor: "border-l-gray-300",
-    badgeBg: "bg-gray-50 text-gray-500 border-gray-200 dark:bg-gray-900 dark:text-gray-400 dark:border-gray-700",
-    label: "Terminé",
-    icon: FileText,
-  },
-  DESISTE: {
-    borderColor: "border-l-gray-300",
-    badgeBg: "bg-gray-50 text-gray-500 border-gray-200 dark:bg-gray-900 dark:text-gray-400 dark:border-gray-700",
-    label: "Désisté",
-    icon: FileText,
-  },
-  CLASSE_SANS_SUITE: {
-    borderColor: "border-l-gray-300",
-    badgeBg: "bg-gray-50 text-gray-500 border-gray-200 dark:bg-gray-900 dark:text-gray-400 dark:border-gray-700",
-    label: "Classé",
-    icon: FileText,
-  },
-};
-
-const formatCurrency = (n: number) =>
-  new Intl.NumberFormat("fr-FR", { style: "currency", currency: "EUR", maximumFractionDigits: 0 }).format(n);
-
-// ─── Helpers ─────────────────────────────────────────────────────────────────
-
-function getLocataireName(parties: Bail["parties"]): string {
-  const loc = parties?.find((p) => p.profilType === ProfilType.LOCATAIRE);
-  if (!loc) return "Locataire non renseigné";
-  if (loc.entreprise) return loc.entreprise.legalName || loc.entreprise.name || "Entreprise";
-  const p = loc.persons?.[0];
-  if (p) return `${p.firstName || ""} ${p.lastName || ""}`.trim() || p.email || "Non renseigné";
-  return "Non renseigné";
-}
-
-function getPropertyLabel(bail: Bail): string {
-  return bail.property.label || (bail.property.fullAddress ? bail.property.fullAddress.split(",")[0] : "Bien");
-}
-
-// ─── Sous-composant : timeline ────────────────────────────────────────────────
-
-function BailTimeline({ status }: { status: string }) {
-  const stepIdx = STEP_INDEX[status] ?? 0;
-  const isTerminated = ["TERMINATED", "DESISTE", "CLASSE_SANS_SUITE"].includes(status);
-  if (isTerminated) return null;
-
-  return (
-    <div className="space-y-1.5">
-      {/* Ligne + dots full width */}
-      <div className="relative">
-        <div className="absolute inset-x-0 top-[5px] h-px bg-border" />
-        <div className="flex justify-between">
-          {STEPS.map((step, i) => {
-            const done = stepIdx > i;
-            const active = stepIdx === i;
-            return (
-              <div
-                key={step.key}
-                className={cn(
-                  "relative z-10 w-2.5 h-2.5 rounded-full transition-all duration-200",
-                  done ? "bg-primary" : active ? "bg-primary ring-[3px] ring-primary/20" : "bg-border"
-                )}
-              />
-            );
-          })}
-        </div>
-      </div>
-      {/* Labels : gauche / milieu absolu centré / droite */}
-      <div className="relative flex justify-between">
-        {STEPS.map((step, i) => {
-          const done = stepIdx > i;
-          const active = stepIdx === i;
-          const colorCn = active
-            ? "font-semibold text-primary"
-            : done
-            ? "text-primary/50"
-            : "text-muted-foreground/50";
-          if (i === 1) {
-            return (
-              <p
-                key={step.key}
-                className={"absolute left-1/2 -translate-x-1/2 text-[9px] text-center transition-colors " + colorCn}
-              >
-                {step.shortLabel}
-              </p>
-            );
-          }
-          return (
-            <p
-              key={step.key}
-              className={"text-[9px] transition-colors " + (i === 0 ? "text-left " : "text-right ") + colorCn}
-            >
-              {step.shortLabel}
-            </p>
-          );
-        })}
-      </div>
-    </div>
-  );
-}
-
-// ─── Carte : dossier bail soumis ──────────────────────────────────────────────
-
-const NO_TENANT_STATUSES = ["DRAFT", "AWAITING_TENANT", "PENDING_VALIDATION", "READY_FOR_NOTARY"];
-
-function DossierCard({ bail }: { bail: Bail }) {
-  const router = useRouter();
-  const [tenantDialogOpen, setTenantDialogOpen] = useState(false);
-  const [tenantEmail, setTenantEmail] = useState("");
-  const [isAddingTenant, setIsAddingTenant] = useState(false);
-  const chatTriggerRef = useRef<HTMLButtonElement>(null);
-
-  const cfg = STATUS_CONFIG[bail.status] ?? STATUS_CONFIG.DRAFT;
-  const StatusIcon = cfg.icon;
-  const locataire = getLocataireName(bail.parties);
-  const property = getPropertyLabel(bail);
-  const address = bail.property.fullAddress;
-  const missingTenant = locataire === "Locataire non renseigné" && NO_TENANT_STATUSES.includes(bail.status);
-  const notaire = bail.dossierAssignments[0]?.notaire ?? null;
-  const hasNotaire = !!notaire;
-  const isTerminated = ["TERMINATED", "DESISTE", "CLASSE_SANS_SUITE"].includes(bail.status);
-  const initials = missingTenant
-    ? "?"
-    : locataire.split(" ").filter(Boolean).map((w) => w[0]).join("").slice(0, 2).toUpperCase() || "L";
-
-  const handleAddTenant = async () => {
-    if (!tenantEmail.includes("@")) { toast.error("Email invalide"); return; }
-    try {
-      setIsAddingTenant(true);
-      await createTenantForLease({ bailId: bail.id, email: tenantEmail });
-      toast.success("Locataire ajouté — un email lui a été envoyé");
-      setTenantDialogOpen(false);
-      setTenantEmail("");
-      router.refresh();
-    } catch (error: any) {
-      toast.error("Erreur", { description: error.message });
-    } finally {
-      setIsAddingTenant(false);
-    }
-  };
-
-  const isSigned = bail.status === "SIGNED";
-  const needsAction = bail.status === "CLIENT_CONTACTED";
-  const info = STATUS_INFO[bail.status];
-
-  return (
-    <>
-      <Card className={cn("transition-all hover:shadow-md group pt-4 pb-3", needsAction && "ring-2 ring-amber-400", isSigned && "ring-1 ring-green-300")}>
-        <CardContent className="px-4 sm:px-5  space-y-3 sm:space-y-4">
-
-          {/* Header : icône + bien + locataire */}
-          <div className="flex items-start justify-between gap-2">
-            <div className="flex items-start gap-2.5 min-w-0">
-              <div className={cn("rounded-full p-1.5 sm:p-2 shrink-0 mt-0.5", isSigned ? "bg-green-100 text-green-600 dark:bg-green-950 dark:text-green-400" : needsAction ? "bg-amber-100 text-amber-600 dark:bg-amber-950 dark:text-amber-400" : "bg-primary/10 text-primary")}>
-                {isSigned ? <Trophy className="h-3.5 w-3.5 sm:h-4 sm:w-4" /> : needsAction ? <AlertCircle className="h-3.5 w-3.5 sm:h-4 sm:w-4" /> : <FileText className="h-3.5 w-3.5 sm:h-4 sm:w-4" />}
-              </div>
-              <div className="min-w-0 flex-1">
-                <p className="font-semibold text-sm sm:text-base truncate leading-tight">{property}</p>
-                <div className="flex items-center gap-1.5 mt-0.5">
-                  <p className={cn("text-xs truncate", missingTenant ? "text-orange-600 dark:text-orange-400" : "text-muted-foreground")}>{locataire}</p>
-                </div>
-              </div>
-            </div>
-            <ChevronRight className="h-4 w-4 text-muted-foreground shrink-0 mt-1 group-hover:translate-x-0.5 transition-transform" />
-          </div>
-
-          {/* Chips : loyer · type bail · dates */}
-          {(bail.rentAmount || bail.bailType || bail.effectiveDate) && (
-            <div className="flex items-center gap-1.5 flex-wrap">
-              {bail.rentAmount != null && bail.rentAmount > 0 && (
-                <span className="inline-flex items-center gap-0.5 px-2 py-0.5 bg-muted rounded-md text-[11px] font-semibold text-foreground">
-                  {formatCurrency(bail.rentAmount)}
-                  <span className="font-normal text-muted-foreground">/mois</span>
-                </span>
-              )}
-              {bail.bailType && (
-                <span className="px-2 py-0.5 bg-muted rounded-md text-[11px] text-muted-foreground">
-                  {BAIL_TYPE_LABELS[bail.bailType] || bail.bailType}
-                </span>
-              )}
-              {bail.effectiveDate && (
-                <span className="inline-flex items-center gap-1 px-2 py-0.5 bg-muted rounded-md text-[11px] text-muted-foreground">
-                  {formatDate(bail.effectiveDate)}
-                  {bail.endDate && (
-                    <>
-                      <ArrowRight className="h-2.5 w-2.5 shrink-0" />
-                      {formatDate(bail.endDate)}
-                    </>
-                  )}
-                </span>
-              )}
-            </div>
-          )}
-
-          {/* Timeline */}
-          <BailTimeline status={bail.status} />
-
-          {/* Bannière locataire manquant */}
-          {missingTenant && (
-            <div className="flex items-start gap-2 rounded-lg px-3 py-2 bg-blue-50 dark:bg-blue-950/30 text-xs sm:text-sm text-blue-800 dark:text-blue-300">
-              <UserPlus className="h-3.5 w-3.5 shrink-0 mt-0.5" />
-              <div className="flex-1 leading-snug">
-                Locataire non renseigné — vous pouvez l'ajouter dès que vous l'avez trouvé.
-                <button
-                  type="button"
-                  onClick={(e) => { e.preventDefault(); e.stopPropagation(); setTenantDialogOpen(true); }}
-                  className="block mt-1.5 text-blue-700 dark:text-blue-400 font-medium underline underline-offset-2 hover:text-blue-900"
-                >
-                  Ajouter un locataire
-                </button>
-              </div>
-            </div>
-          )}
-
-          {/* Message statut */}
-          {info && !missingTenant && (
-            <div className={cn("flex items-start gap-2 rounded-lg px-3 py-2 text-xs sm:text-sm", needsAction ? "bg-amber-50 text-amber-800 dark:bg-amber-950/60 dark:text-amber-200" : isSigned ? "bg-green-50 text-green-800 dark:bg-green-950/60 dark:text-green-200" : "bg-muted/70 text-muted-foreground")}>
-              {needsAction ? <AlertCircle className="h-3.5 w-3.5 shrink-0 mt-0.5" /> : isSigned ? <Sparkles className="h-3.5 w-3.5 shrink-0 mt-0.5" /> : <Clock className="h-3.5 w-3.5 shrink-0 mt-0.5" />}
-              <span className="leading-snug">{info.message}</span>
-            </div>
-          )}
-
-          {/* Footer actions */}
-          <div className="flex items-center gap-1 pt-1 border-t border-border/60">
-            <Link
-              href={`/client/proprietaire/demandes?open=bail-${bail.id}`}
-              className="flex-1 flex items-center justify-center gap-1.5 text-xs font-medium text-primary hover:text-primary/80 py-1.5 rounded-lg hover:bg-primary/5 transition-colors"
-            >
-              <ExternalLink className="w-3 h-3" />
-              Voir le dossier
-            </Link>
-            <div className="w-px h-5 bg-border/60 shrink-0" />
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button variant="ghost" size="icon" className="h-8 w-8 shrink-0 text-muted-foreground hover:text-foreground">
-                  <MoreHorizontal className="w-4 h-4" />
-                  <span className="sr-only">Actions</span>
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end" className="w-52">
-                <DropdownMenuItem asChild>
-                  <Link href={`/client/proprietaire/demandes?open=bail-${bail.id}`}>
-                    <FileText className="mr-2 h-4 w-4" />
-                    Voir le dossier
-                  </Link>
-                </DropdownMenuItem>
-                {hasNotaire && (
-                  <>
-                    <DropdownMenuSeparator />
-                    <DropdownMenuItem onSelect={() => setTimeout(() => chatTriggerRef.current?.click(), 0)}>
-                      <MessageSquare className="mr-2 h-4 w-4" />
-                      Contacter le notaire
-                    </DropdownMenuItem>
-                  </>
-                )}
-                {missingTenant && (
-                  <>
-                    <DropdownMenuSeparator />
-                    <DropdownMenuItem onSelect={() => setTenantDialogOpen(true)}>
-                      <UserPlus className="mr-2 h-4 w-4" />
-                      Ajouter un locataire
-                    </DropdownMenuItem>
-                  </>
-                )}
-              </DropdownMenuContent>
-            </DropdownMenu>
-          </div>
-
-        </CardContent>
-      </Card>
-
-      {/* BailChatSheet déclenché via ref depuis le dropdown */}
-      {hasNotaire && (
-        <BailChatSheet
-          bailId={bail.id}
-          trigger={<button ref={chatTriggerRef} className="sr-only" tabIndex={-1} aria-hidden="true" />}
-        />
-      )}
-
-      {/* Dialog ajout locataire */}
-      <Dialog open={tenantDialogOpen} onOpenChange={setTenantDialogOpen}>
-        <DialogContent className="sm:max-w-md">
-          <DialogHeader>
-            <DialogTitle className="flex items-center gap-2">
-              <UserPlus className="h-5 w-5" />
-              Ajouter un locataire
-            </DialogTitle>
-            <DialogDescription>
-              Entrez l'adresse email de votre locataire. Il recevra un lien pour compléter son dossier.
-            </DialogDescription>
-          </DialogHeader>
-          <div className="space-y-2 py-2">
-            <Label>Email *</Label>
-            <Input
-              type="email"
-              placeholder="locataire@example.com"
-              value={tenantEmail}
-              onChange={(e) => setTenantEmail(e.target.value)}
-              disabled={isAddingTenant}
-              inputMode="email"
-              autoComplete="email"
-              className="h-11"
-              onKeyDown={(e) => { if (e.key === "Enter") handleAddTenant(); }}
-            />
-          </div>
-          <DialogFooter className="flex-col sm:flex-col gap-2">
-            <Button onClick={handleAddTenant} disabled={isAddingTenant || !tenantEmail} className="w-full">
-              {isAddingTenant ? <><Loader2 className="mr-2 h-4 w-4 animate-spin" />Ajout en cours...</> : <><UserPlus className="mr-2 h-4 w-4" />Ajouter le locataire</>}
-            </Button>
-            <Button variant="outline" onClick={() => { setTenantDialogOpen(false); setTenantEmail(""); }} disabled={isAddingTenant} className="w-full">
-              Annuler
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
-    </>
-  );
-}
-
 // ─── Carte : intake en cours ──────────────────────────────────────────────────
 
 function IntakeCard({ intake }: { intake: ActiveIntake }) {
   const stageLabel = STAGE_LABELS[intake.stage];
 
   return (
-    <Card className="border-amber-200 dark:border-amber-800 bg-amber-50/40 dark:bg-amber-950/20 transition-all hover:shadow-md ">
-      <CardContent className="px-4 sm:px-5">
-        <div className="flex items-start gap-2.5 min-w-0">
-          <div className="rounded-full bg-amber-100 dark:bg-amber-900 p-1.5 sm:p-2 shrink-0 mt-0.5">
-            <ClipboardList className="h-3.5 w-3.5 sm:h-4 sm:w-4 text-amber-600 dark:text-amber-400" />
-          </div>
-          <div className="min-w-0 flex-1">
-            <p className="font-semibold text-sm sm:text-base leading-tight text-amber-900 dark:text-amber-200">
-              Demande de bail en cours
-            </p>
-            {intake.propertyLabel ? (
-              <p className="text-xs text-amber-700 dark:text-amber-400 mt-0.5 truncate">{intake.propertyLabel}</p>
-            ) : (
-              <p className="text-xs text-amber-600/70 dark:text-amber-500 mt-0.5 italic">Bien non renseigné</p>
-            )}
-            {intake.bailType && (
-              <p className="text-[11px] text-amber-600/80 dark:text-amber-500 mt-0.5">{BAIL_TYPE_LABELS[intake.bailType] || intake.bailType}</p>
-            )}
-          </div>
-        </div>
-        <div className="mt-3 flex items-start gap-2 rounded-lg px-3 py-2 bg-amber-100/60 dark:bg-amber-900/30 text-xs sm:text-sm text-amber-800 dark:text-amber-300">
-          <AlertCircle className="h-3.5 w-3.5 shrink-0 mt-0.5" />
-          <span className="leading-snug">À compléter : {stageLabel} — {intake.description}</span>
-        </div>
-        <div className="mt-3">
-          <Button asChild size="sm" variant="outline" className="border-amber-300 text-amber-800 hover:bg-amber-100 dark:border-amber-700 dark:text-amber-300">
-            <Link href={intake.intakeUrl}>Continuer ma demande</Link>
-          </Button>
-        </div>
-      </CardContent>
-    </Card>
+    <OwnerProgressCard
+      propertyLabel={intake.propertyLabel}
+      bailTypeLabel={intake.bailType ? BAIL_TYPE_LABELS[intake.bailType] || intake.bailType : null}
+      message={`À compléter : ${stageLabel} — ${intake.description}`}
+      continueHref={intake.intakeUrl}
+    />
   );
 }
 
@@ -613,49 +157,15 @@ function DraftCard({ draft, onDelete }: { draft: BailDraft; onDelete: (id: strin
   };
 
   return (
-    <Card className="border-amber-200 dark:border-amber-800 bg-amber-50/40 dark:bg-amber-950/20 transition-all hover:shadow-md">
-      <CardContent className="p-4 sm:p-5">
-        <div className="flex items-start gap-2.5 min-w-0">
-          <div className="rounded-full bg-amber-100 dark:bg-amber-900 p-1.5 sm:p-2 shrink-0 mt-0.5">
-            <ClipboardList className="h-3.5 w-3.5 sm:h-4 sm:w-4 text-amber-600 dark:text-amber-400" />
-          </div>
-          <div className="min-w-0 flex-1">
-            <p className="font-semibold text-sm sm:text-base leading-tight text-amber-900 dark:text-amber-200">
-              Demande de bail en cours
-            </p>
-            <p className="text-xs text-amber-700 dark:text-amber-400 mt-0.5 truncate">{propertyLabel}</p>
-            {tenantName && (
-              <div className="flex items-center gap-1 mt-0.5">
-                <User className="h-3 w-3 text-amber-600/70 dark:text-amber-500 shrink-0" />
-                <p className="text-[11px] text-amber-600/80 dark:text-amber-500 truncate">{tenantName}</p>
-              </div>
-            )}
-            {draft.bailType && (
-              <p className="text-[11px] text-amber-600/80 dark:text-amber-500 mt-0.5">{BAIL_TYPE_LABELS[draft.bailType] || draft.bailType}</p>
-            )}
-          </div>
-        </div>
-        <div className="mt-3 flex items-start gap-2 rounded-lg px-3 py-2 bg-amber-100/60 dark:bg-amber-900/30 text-xs sm:text-sm text-amber-800 dark:text-amber-300">
-          <AlertCircle className="h-3.5 w-3.5 shrink-0 mt-0.5" />
-          <span className="leading-snug">À compléter : {stepLabel} — {description}</span>
-        </div>
-        <div className="mt-3 flex items-center gap-2">
-          <Button asChild size="sm" variant="outline" className="border-amber-300 text-amber-800 hover:bg-amber-100 dark:border-amber-700 dark:text-amber-300">
-            <Link href={`/client/proprietaire/baux/new?draftId=${draft.id}`}>Continuer ma demande</Link>
-          </Button>
-          <Button
-            size="sm"
-            variant="ghost"
-            onClick={handleDelete}
-            disabled={deleting}
-            className="text-amber-700 hover:text-destructive dark:text-amber-400 h-8 px-2"
-          >
-            <Trash2 className="h-3.5 w-3.5 mr-1" />
-            Supprimer
-          </Button>
-        </div>
-      </CardContent>
-    </Card>
+    <OwnerProgressCard
+      propertyLabel={propertyLabel}
+      tenantName={tenantName}
+      bailTypeLabel={draft.bailType ? BAIL_TYPE_LABELS[draft.bailType] || draft.bailType : null}
+      message={`À compléter : ${stepLabel} — ${description}`}
+      continueHref={`/client/proprietaire/baux/new?draftId=${draft.id}`}
+      onDelete={handleDelete}
+      deleting={deleting}
+    />
   );
 }
 
@@ -818,7 +328,12 @@ export function DashboardProprietaireClient({
 
           {/* Bails soumis */}
           {recentBails.map((bail) => (
-            <DossierCard key={bail.id} bail={bail} />
+            <OwnerBailCard
+              key={bail.id}
+              bail={bail}
+              context="dashboard"
+              detailHref={`/client/proprietaire/demandes?open=bail-${bail.id}`}
+            />
           ))}
         </div>
 

--- a/components/client/demandes-page-client.tsx
+++ b/components/client/demandes-page-client.tsx
@@ -132,6 +132,7 @@ const BAIL_STEPS = [
 const BAIL_STEP_INDEX: Record<string, number> = {
   DRAFT: 0,
   AWAITING_TENANT: 0,
+  AWAITING_TENANT_FORM: 0,
   PENDING_VALIDATION: 0,
   READY_FOR_NOTARY: 1,
   CLIENT_CONTACTED: 1,
@@ -142,6 +143,7 @@ const BAIL_STEP_INDEX: Record<string, number> = {
 const BAIL_STATUS_CONFIG: Record<string, { badgeBg: string; label: string; icon: React.ElementType }> = {
   DRAFT: { badgeBg: "bg-blue-50 text-blue-700 border-blue-200", label: "En vérification", icon: Clock },
   AWAITING_TENANT: { badgeBg: "bg-orange-50 text-orange-700 border-orange-200", label: "Locataire manquant", icon: User },
+  AWAITING_TENANT_FORM: { badgeBg: "bg-indigo-50 text-indigo-700 border-indigo-200", label: "Formulaire locataire en attente", icon: Clock },
   PENDING_VALIDATION: { badgeBg: "bg-blue-50 text-blue-700 border-blue-200", label: "En vérification", icon: Clock },
   READY_FOR_NOTARY: { badgeBg: "bg-violet-50 text-violet-700 border-violet-200", label: "Chez le notaire", icon: Scale },
   CLIENT_CONTACTED: { badgeBg: "bg-violet-50 text-violet-700 border-violet-200", label: "Chez le notaire", icon: Scale },

--- a/components/client/demandes-page-client.tsx
+++ b/components/client/demandes-page-client.tsx
@@ -5,11 +5,10 @@ import { useSearchParams, useRouter } from "next/navigation";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
-import { Plus, Home, FileText, Building2, User, Calendar, Euro, Eye, Loader2, CheckCircle2, MessageSquare, MoreHorizontal, ExternalLink, ArrowRight, Clock, Scale, Store, AlertCircle, ClipboardList, Lock } from "lucide-react";
+import { Plus, Home, FileText, Building2, Eye, Loader2, CheckCircle2, Lock } from "lucide-react";
 import Link from "next/link";
-import { formatDate } from "@/lib/utils/formatters";
 import { DemandesTabs } from "./demandes-tabs";
-import { CompletionStatus, BailType, BailFamille, ProfilType } from "@prisma/client";
+import { CompletionStatus, BailType, ProfilType } from "@prisma/client";
 import { cn } from "@/lib/utils";
 import { BailDetailDrawer } from "./bail-detail-drawer";
 import { PropertyDetailDrawer } from "./property-detail-drawer";
@@ -23,13 +22,8 @@ import {
   DialogDescription,
   DialogFooter,
 } from "@/components/ui/dialog";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
-import { BailChatSheet } from "./bail-chat-sheet";
+import { OwnerBailCard } from "./owner-bail-card";
+import { OwnerProgressCard } from "./owner-progress-card";
 
 type PropertyWithBails = {
   id: string;
@@ -125,11 +119,6 @@ const bailTypeLabels: Record<BailType, string> = {
   BAIL_MEUBLE_9_MOIS: "Bail meublé 9 mois",
 };
 
-const bailFamilyLabels: Record<BailFamille, string> = {
-  HABITATION: "Bail d'habitation",
-  COMMERCIAL: "Bail commercial",
-};
-
 const TERMINAL_STATUSES = ["TERMINATED", "DESISTE", "CLASSE_SANS_SUITE"];
 
 function canCreateNewBail(bails: PropertyWithBails["bails"]): boolean {
@@ -147,85 +136,6 @@ function canCreateNewBail(bails: PropertyWithBails["bails"]): boolean {
     oneMonthBefore.setMonth(oneMonthBefore.getMonth() - 1);
     return new Date() >= oneMonthBefore;
   });
-}
-
-const BAIL_STEPS = [
-  { key: "verification", shortLabel: "Vérification" },
-  { key: "notaire", shortLabel: "Notaire" },
-  { key: "signe", shortLabel: "Signé" },
-];
-
-const BAIL_STEP_INDEX: Record<string, number> = {
-  DRAFT: 0,
-  AWAITING_TENANT: 0,
-  AWAITING_TENANT_FORM: 0,
-  PENDING_VALIDATION: 0,
-  READY_FOR_NOTARY: 1,
-  CLIENT_CONTACTED: 1,
-  SIGNED: 2,
-  TERMINATED: 2,
-};
-
-const BAIL_STATUS_CONFIG: Record<string, { badgeBg: string; label: string; icon: React.ElementType }> = {
-  DRAFT: { badgeBg: "bg-blue-50 text-blue-700 border-blue-200", label: "En vérification", icon: Clock },
-  AWAITING_TENANT: { badgeBg: "bg-orange-50 text-orange-700 border-orange-200", label: "Locataire manquant", icon: User },
-  AWAITING_TENANT_FORM: { badgeBg: "bg-indigo-50 text-indigo-700 border-indigo-200", label: "Formulaire locataire en attente", icon: Clock },
-  PENDING_VALIDATION: { badgeBg: "bg-blue-50 text-blue-700 border-blue-200", label: "En vérification", icon: Clock },
-  READY_FOR_NOTARY: { badgeBg: "bg-violet-50 text-violet-700 border-violet-200", label: "Chez le notaire", icon: Scale },
-  CLIENT_CONTACTED: { badgeBg: "bg-violet-50 text-violet-700 border-violet-200", label: "Chez le notaire", icon: Scale },
-  SIGNED: { badgeBg: "bg-green-50 text-green-700 border-green-200", label: "Signé", icon: CheckCircle2 },
-  TERMINATED: { badgeBg: "bg-gray-100 text-gray-500 border-gray-200", label: "Terminé", icon: FileText },
-};
-
-function BailStatusTimeline({ status }: { status: string }) {
-  const stepIdx = BAIL_STEP_INDEX[status] ?? 0;
-  const isTerminated = ["TERMINATED"].includes(status);
-
-  return (
-    <div className="space-y-1.5">
-      <div className="relative">
-        <div className="absolute inset-x-0 top-[5px] h-px bg-border" />
-        <div className="flex justify-between">
-          {BAIL_STEPS.map((step, i) => {
-            const done = isTerminated || stepIdx > i;
-            const active = !isTerminated && stepIdx === i;
-            return (
-              <div
-                key={step.key}
-                className={cn(
-                  "relative z-10 w-2.5 h-2.5 rounded-full transition-all",
-                  done ? "bg-primary" : active ? "bg-primary ring-[3px] ring-primary/20" : "bg-border"
-                )}
-              />
-            );
-          })}
-        </div>
-      </div>
-      <div className="relative flex justify-between">
-        {BAIL_STEPS.map((step, i) => {
-          const done = isTerminated || stepIdx > i;
-          const active = !isTerminated && stepIdx === i;
-          const colorCn = active
-            ? "font-semibold text-primary"
-            : done
-            ? "text-primary/50"
-            : "text-muted-foreground/50";
-          if (i === 1) {
-            return (
-              <p key={step.key} className={cn("absolute left-1/2 -translate-x-1/2 text-[9px] text-center", colorCn)}>
-                {step.shortLabel}
-              </p>
-            );
-          }
-          return (
-            <p key={step.key} className={cn("text-[9px]", i === 0 ? "text-left" : "text-right", colorCn)}>
-              {step.shortLabel}
-            </p>
-          );
-        })}
-      </div>
-    </div>
-  );
 }
 
 export function DemandesPageClient({ biens, locataires, ownerId }: DemandesPageClientProps) {
@@ -576,38 +486,22 @@ export function DemandesPageClient({ biens, locataires, ownerId }: DemandesPageC
                           : `/client/proprietaire/baux/new?draftId=${draftBail.id}`;
 
                         return (
-                          <Card className="border-amber-200 dark:border-amber-800 bg-amber-50/40 dark:bg-amber-950/20 transition-all hover:shadow-md">
-                            <CardContent className="p-4 sm:p-5">
-                              <div className="flex items-start gap-2.5 min-w-0">
-                                <div className="rounded-full bg-amber-100 dark:bg-amber-900 p-1.5 sm:p-2 shrink-0 mt-0.5">
-                                  <ClipboardList className="h-3.5 w-3.5 sm:h-4 sm:w-4 text-amber-600 dark:text-amber-400" />
-                                </div>
-                                <div className="min-w-0 flex-1">
-                                  <p className="font-semibold text-sm sm:text-base leading-tight text-amber-900 dark:text-amber-200">
-                                    Demande de bail en cours
-                                  </p>
-                                  <p className="text-xs text-amber-700 dark:text-amber-400 mt-0.5 truncate">
-                                    {selectedProperty?.label || selectedProperty?.fullAddress || "Bien sélectionné"}
-                                  </p>
-                                  {locataireName && (
-                                    <div className="flex items-center gap-1 mt-0.5">
-                                      <User className="h-3 w-3 text-amber-600/70 dark:text-amber-500 shrink-0" />
-                                      <p className="text-[11px] text-amber-600/80 dark:text-amber-500 truncate">{locataireName}</p>
-                                    </div>
-                                  )}
-                                </div>
-                              </div>
-                              <div className="mt-3 flex items-start gap-2 rounded-lg px-3 py-2 bg-amber-100/60 dark:bg-amber-900/30 text-xs sm:text-sm text-amber-800 dark:text-amber-300">
-                                <AlertCircle className="h-3.5 w-3.5 shrink-0 mt-0.5" />
-                                <span className="leading-snug">Ce dossier n'est pas encore finalisé. Reprenez là où vous en étiez.</span>
-                              </div>
-                              <div className="mt-3">
-                                <Button asChild size="sm" variant="outline" className="border-amber-300 text-amber-800 hover:bg-amber-100 dark:border-amber-700 dark:text-amber-300">
-                                  <Link href={href}>Continuer ma demande</Link>
-                                </Button>
-                              </div>
-                            </CardContent>
-                          </Card>
+                          <OwnerProgressCard
+                            propertyLabel={
+                              selectedProperty.label ||
+                              selectedProperty.fullAddress ||
+                              "Bien sélectionné"
+                            }
+                            tenantName={locataireName}
+                            bailTypeLabel={
+                              draftBail.bailType
+                                ? bailTypeLabels[draftBail.bailType as BailType] ||
+                                  draftBail.bailType
+                                : null
+                            }
+                            message="Ce dossier n'est pas encore finalisé. Reprenez là où vous en étiez."
+                            continueHref={href}
+                          />
                         );
                       }
 
@@ -656,143 +550,16 @@ export function DemandesPageClient({ biens, locataires, ownerId }: DemandesPageC
                     {/* Liste des baux (exclure les DRAFT non payés, déjà affichés au-dessus) */}
                     {(selectedProperty.bails?.filter((b) => !(b.status === "DRAFT" && !b.paidAt))?.length || 0) > 0 ? (
                       <div className="space-y-3">
-                        {(selectedProperty.bails || []).filter((b) => !(b.status === "DRAFT" && !b.paidAt)).map((bail) => {
-                          const locataire = bail.parties?.find(
-                            (p) => p.profilType === ProfilType.LOCATAIRE
-                          );
-                          const locataireName = locataire?.entreprise
-                            ? locataire.entreprise.legalName || locataire.entreprise.name || "Entreprise"
-                            : locataire?.persons?.[0]
-                            ? `${locataire.persons[0].firstName || ""} ${locataire.persons[0].lastName || ""}`.trim() || locataire.persons[0].email || "Non défini"
-                            : null;
-                          const locataireInitial = locataireName ? locataireName[0].toUpperCase() : null;
-
-                          const notaire = bail.dossierAssignments?.[0]?.notaire;
-                          const notaireName = notaire
-                            ? notaire.name || notaire.email || "Notaire"
-                            : null;
-
-                          const endDate = bail.endDate
-                            ? bail.endDate
-                            : bail.effectiveDate && bail.bailType
-                            ? calculateBailEndDate(new Date(bail.effectiveDate), bail.bailType as BailType).toISOString()
-                            : null;
-
-                          const chatTriggerRef = { current: null as HTMLButtonElement | null };
-
-                          const cfg = BAIL_STATUS_CONFIG[bail.status] ?? BAIL_STATUS_CONFIG.DRAFT;
-                          const StatusIcon = cfg.icon;
-                          const isCommercial = bail.bailFamily === BailFamille.COMMERCIAL;
-
-                          return (
-                            <Card key={bail.id} className="border shadow-sm hover:shadow-md transition-shadow overflow-hidden pb-2 pt-0">
-                              <CardContent className="p-0">
-                                <div className="p-4 space-y-3.5">
-                                  {/* Titre : famille du bail */}
-                                  <div className="flex items-center justify-between gap-2">
-                                    <div className="flex items-center gap-2">
-                                      <div className={cn(
-                                        "rounded-md p-1.5",
-                                        isCommercial ? "bg-amber-100 text-amber-700" : "bg-blue-100 text-blue-700"
-                                      )}>
-                                        {isCommercial ? <Store className="h-3.5 w-3.5" /> : <Home className="h-3.5 w-3.5" />}
-                                      </div>
-                                      <span className="text-sm font-semibold">
-                                        {bail.bailFamily ? bailFamilyLabels[bail.bailFamily as BailFamille] : "Bail"}
-                                      </span>
-                                    </div>
-
-                                    <DropdownMenu>
-                                    <DropdownMenuTrigger asChild>
-                                      <Button size="sm" variant="ghost" className="px-2">
-                                        <MoreHorizontal className="h-4 w-4" />
-                                      </Button>
-                                    </DropdownMenuTrigger>
-                                    <DropdownMenuContent align="end">
-                                      <DropdownMenuItem onClick={() => handleOpenBailDetail(bail.id)}>
-                                        <FileText className="h-4 w-4 mr-2" />
-                                        Voir le dossier complet
-                                      </DropdownMenuItem>
-                                    </DropdownMenuContent>
-                                  </DropdownMenu>
-
-                                  </div>
-    
-                                  {/* Chips : loyer / type / dates */}
-                                  <div className="flex flex-wrap gap-1.5 items-center">
-                                    {bail.rentAmount != null && bail.rentAmount > 0 && (
-                                      <span className="inline-flex items-center gap-1 text-xs font-semibold bg-primary/10 text-primary rounded-full px-2.5 py-1">
-                                        {bail.rentAmount.toLocaleString()} €/mois
-                                      </span>
-                                    )}
-                                    {bail.bailType && (
-                                      <span className="inline-flex items-center gap-1 text-xs bg-muted text-muted-foreground rounded-full px-2.5 py-1">
-                                        <FileText className="h-3 w-3" />
-                                        {bailTypeLabels[bail.bailType as BailType] || bail.bailType}
-                                      </span>
-                                    )}
-                                    {bail.effectiveDate && (
-                                      <span className="inline-flex items-center gap-1 text-xs bg-muted text-muted-foreground rounded-full px-2.5 py-1">
-                                        <Calendar className="h-3 w-3" />
-                                        {formatDate(bail.effectiveDate)}
-                                        {endDate && (
-                                          <>
-                                            <ArrowRight className="h-2.5 w-2.5 shrink-0" />
-                                            {formatDate(endDate)}
-                                          </>
-                                        )}
-                                      </span>
-                                    )}
-                                  </div>
-
-                                  {/* Locataire */}
-                                  <div className="flex items-center gap-2">
-                                    <div className={cn(
-                                      "h-6 w-6 rounded-full flex items-center justify-center text-xs font-semibold shrink-0",
-                                      locataireName ? "bg-primary/20 text-primary" : "bg-muted"
-                                    )}>
-                                      {locataireName ? locataireInitial : <User className="h-3 w-3 text-muted-foreground" />}
-                                    </div>
-                                    <div className="flex flex-col min-w-0">
-                                      <span className="text-[10px] font-medium text-muted-foreground uppercase tracking-wide leading-none mb-0.5">Locataire</span>
-                                      <span className={cn("text-sm truncate", locataireName ? "text-foreground" : "text-muted-foreground italic text-xs")}>
-                                        {locataireName ?? "Non renseigné"}
-                                      </span>
-                                    </div>
-                                  </div>
-
- 
-                                  {/* timeline */}
-                                  <div className="space-y-2">
-                                    <BailStatusTimeline status={bail.status} />
-                                  </div>
-                                </div>
-
-                                {/* Footer d'actions */}
-                                <div className="border-t px-4 py-3 flex items-center gap-2 bg-muted/30">
-                                  {notaire ? (
-                                    <BailChatSheet
-                                      bailId={bail.id}
-                                      trigger={
-                                        <Button size="sm" className="flex-1 gap-1.5">
-                                          <MessageSquare className="h-3.5 w-3.5" />
-                                          Contacter le notaire
-                                        </Button>
-                                      }
-                                    />
-                                  ) : (
-                                    <div className="flex-1 flex items-center gap-1.5 text-xs text-muted-foreground bg-muted/50 rounded-md px-3 py-2">
-                                      <Clock className="h-3.5 w-3.5 shrink-0" />
-                                      Assignation au notaire en cours…
-                                    </div>
-                                  )}
-
-                                  
-                                </div>
-                              </CardContent>
-                            </Card>
-                          );
-                        })}
+                        {(selectedProperty.bails || [])
+                          .filter((b) => !(b.status === "DRAFT" && !b.paidAt))
+                          .map((bail) => (
+                            <OwnerBailCard
+                              key={bail.id}
+                              bail={{ ...bail, property: selectedProperty }}
+                              context="dossiers"
+                              onViewDetail={() => handleOpenBailDetail(bail.id)}
+                            />
+                          ))}
                       </div>
                     ) : !(selectedProperty.bails || []).some((b) => b.status === "DRAFT" && !b.paidAt) ? (
                       <Card>

--- a/components/client/demandes-page-client.tsx
+++ b/components/client/demandes-page-client.tsx
@@ -795,7 +795,7 @@ export function DemandesPageClient({ biens, locataires, ownerId }: DemandesPageC
                           );
                         })}
                       </div>
-                    ) : (
+                    ) : !(selectedProperty.bails || []).some((b) => b.status === "DRAFT" && !b.paidAt) ? (
                       <Card>
                         <CardContent className="py-12 text-center">
                           <FileText className="mx-auto h-12 w-12 text-muted-foreground mb-4" />
@@ -805,7 +805,7 @@ export function DemandesPageClient({ biens, locataires, ownerId }: DemandesPageC
                           </p>
                         </CardContent>
                       </Card>
-                    )}
+                    ) : null}
                 </div>
               </div>
             </>

--- a/components/client/demandes-page-client.tsx
+++ b/components/client/demandes-page-client.tsx
@@ -620,9 +620,9 @@ export function DemandesPageClient({ biens, locataires, ownerId }: DemandesPageC
                                   <Lock className="h-6 w-6 text-muted-foreground" />
                                 </div>
                                 <div>
-                                  <h3 className="font-semibold text-base mb-1 text-muted-foreground">Bail en cours pour ce bien</h3>
+                                  <h3 className="font-semibold text-base mb-1 text-muted-foreground">Un bail est déjà actif sur ce bien</h3>
                                   <p className="text-sm text-muted-foreground">
-                                    Vous pourrez créer un nouveau bail 1 mois avant la fin du bail actuel.
+                                    Nouveau bail possible 1 mois avant la fin du bail en cours.
                                   </p>
                                 </div>
                               </div>
@@ -722,7 +722,6 @@ export function DemandesPageClient({ biens, locataires, ownerId }: DemandesPageC
                                   <div className="flex flex-wrap gap-1.5 items-center">
                                     {bail.rentAmount != null && bail.rentAmount > 0 && (
                                       <span className="inline-flex items-center gap-1 text-xs font-semibold bg-primary/10 text-primary rounded-full px-2.5 py-1">
-                                        <Euro className="h-3 w-3" />
                                         {bail.rentAmount.toLocaleString()} €/mois
                                       </span>
                                     )}

--- a/components/client/demandes-page-client.tsx
+++ b/components/client/demandes-page-client.tsx
@@ -5,7 +5,8 @@ import { useSearchParams, useRouter } from "next/navigation";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
-import { Plus, Home, FileText, Building2, User, Calendar, Euro, Eye, Loader2, CheckCircle2, MessageSquare, MoreHorizontal, ExternalLink, ArrowRight, Clock, Scale, Store } from "lucide-react";
+import { Plus, Home, FileText, Building2, User, Calendar, Euro, Eye, Loader2, CheckCircle2, MessageSquare, MoreHorizontal, ExternalLink, ArrowRight, Clock, Scale, Store, AlertCircle, ClipboardList, Lock } from "lucide-react";
+import Link from "next/link";
 import { formatDate } from "@/lib/utils/formatters";
 import { DemandesTabs } from "./demandes-tabs";
 import { CompletionStatus, BailType, BailFamille, ProfilType } from "@prisma/client";
@@ -48,6 +49,7 @@ type PropertyWithBails = {
     rentAmount?: number | null;
     bailType?: string | null;
     bailFamily?: string | null;
+    paidAt?: string | null;
     parties?: Array<{
       id: string;
       profilType: string;
@@ -68,6 +70,11 @@ type PropertyWithBails = {
         name: string | null;
         email: string | null;
       } | null;
+    }>;
+    intakes?: Array<{
+      id: string;
+      token: string;
+      status: string;
     }>;
   }>;
 };
@@ -122,6 +129,25 @@ const bailFamilyLabels: Record<BailFamille, string> = {
   HABITATION: "Bail d'habitation",
   COMMERCIAL: "Bail commercial",
 };
+
+const TERMINAL_STATUSES = ["TERMINATED", "DESISTE", "CLASSE_SANS_SUITE"];
+
+function canCreateNewBail(bails: PropertyWithBails["bails"]): boolean {
+  const activeBails = bails.filter((b) => !TERMINAL_STATUSES.includes(b.status));
+  if (activeBails.length === 0) return true;
+
+  return activeBails.every((b) => {
+    const endDate = b.endDate
+      ? new Date(b.endDate)
+      : b.effectiveDate && b.bailType
+      ? calculateBailEndDate(new Date(b.effectiveDate), b.bailType as BailType)
+      : null;
+    if (!endDate) return false;
+    const oneMonthBefore = new Date(endDate);
+    oneMonthBefore.setMonth(oneMonthBefore.getMonth() - 1);
+    return new Date() >= oneMonthBefore;
+  });
+}
 
 const BAIL_STEPS = [
   { key: "verification", shortLabel: "Vérification" },
@@ -531,29 +557,106 @@ export function DemandesPageClient({ biens, locataires, ownerId }: DemandesPageC
               {/* Contenu */}
               <div className="flex-1 overflow-y-auto no-scrollbar p-4 sm:p-6">
                 <div className="space-y-4">
-                    <Card
-                      onClick={() => router.push(`/client/proprietaire/baux/new${selectedPropertyId ? `?propertyId=${selectedPropertyId}` : ""}`)}
-                      className="border-2 border-dashed hover:border-primary hover:bg-primary/5 transition-all cursor-pointer group"
-                    >
-                      <CardContent className="flex flex-col items-center justify-center px-0">
-                        <div className="flex flex-row items-center gap-10 text-center">
-                          <div className="rounded-full bg-primary/10 p-3 group-hover:bg-primary/20 transition-colors">
-                            <Plus className="h-6 w-6 text-primary" />
-                          </div>
-                          <div>
-                            <h3 className="font-semibold text-base mb-1">Démarrer un dossier pour</h3>
-                            <p className="text-sm text-muted-foreground">
-                              {selectedProperty?.label || selectedProperty?.fullAddress || "Bien sélectionné"}
-                            </p>
-                          </div>
-                        </div>
-                      </CardContent>
-                    </Card>
+                    {(() => {
+                      const allowed = canCreateNewBail(selectedProperty.bails || []);
+                      const draftBail = (selectedProperty.bails || []).find(
+                        (b) => b.status === "DRAFT" && !b.paidAt
+                      );
+                      const intakeLink = draftBail?.intakes?.[0];
 
-                    {/* Liste des baux */}
-                    {(selectedProperty.bails?.length || 0) > 0 ? (
+                      if (draftBail) {
+                        const locataire = draftBail.parties?.find((p) => p.profilType === ProfilType.LOCATAIRE);
+                        const locataireName = locataire?.entreprise
+                          ? locataire.entreprise.legalName || locataire.entreprise.name
+                          : locataire?.persons?.[0]
+                          ? `${locataire.persons[0].firstName || ""} ${locataire.persons[0].lastName || ""}`.trim() || locataire.persons[0].email
+                          : null;
+                        const href = intakeLink
+                          ? `/intakes/${intakeLink.token}`
+                          : `/client/proprietaire/baux/new?draftId=${draftBail.id}`;
+
+                        return (
+                          <Card className="border-amber-200 dark:border-amber-800 bg-amber-50/40 dark:bg-amber-950/20 transition-all hover:shadow-md">
+                            <CardContent className="p-4 sm:p-5">
+                              <div className="flex items-start gap-2.5 min-w-0">
+                                <div className="rounded-full bg-amber-100 dark:bg-amber-900 p-1.5 sm:p-2 shrink-0 mt-0.5">
+                                  <ClipboardList className="h-3.5 w-3.5 sm:h-4 sm:w-4 text-amber-600 dark:text-amber-400" />
+                                </div>
+                                <div className="min-w-0 flex-1">
+                                  <p className="font-semibold text-sm sm:text-base leading-tight text-amber-900 dark:text-amber-200">
+                                    Demande de bail en cours
+                                  </p>
+                                  <p className="text-xs text-amber-700 dark:text-amber-400 mt-0.5 truncate">
+                                    {selectedProperty?.label || selectedProperty?.fullAddress || "Bien sélectionné"}
+                                  </p>
+                                  {locataireName && (
+                                    <div className="flex items-center gap-1 mt-0.5">
+                                      <User className="h-3 w-3 text-amber-600/70 dark:text-amber-500 shrink-0" />
+                                      <p className="text-[11px] text-amber-600/80 dark:text-amber-500 truncate">{locataireName}</p>
+                                    </div>
+                                  )}
+                                </div>
+                              </div>
+                              <div className="mt-3 flex items-start gap-2 rounded-lg px-3 py-2 bg-amber-100/60 dark:bg-amber-900/30 text-xs sm:text-sm text-amber-800 dark:text-amber-300">
+                                <AlertCircle className="h-3.5 w-3.5 shrink-0 mt-0.5" />
+                                <span className="leading-snug">Ce dossier n'est pas encore finalisé. Reprenez là où vous en étiez.</span>
+                              </div>
+                              <div className="mt-3">
+                                <Button asChild size="sm" variant="outline" className="border-amber-300 text-amber-800 hover:bg-amber-100 dark:border-amber-700 dark:text-amber-300">
+                                  <Link href={href}>Continuer ma demande</Link>
+                                </Button>
+                              </div>
+                            </CardContent>
+                          </Card>
+                        );
+                      }
+
+                      if (!allowed) {
+                        return (
+                          <Card className="border-2 border-dashed border-muted-foreground/20 opacity-60">
+                            <CardContent className="flex flex-col items-center justify-center px-0">
+                              <div className="flex flex-row items-center gap-10 text-center">
+                                <div className="rounded-full bg-muted p-3">
+                                  <Lock className="h-6 w-6 text-muted-foreground" />
+                                </div>
+                                <div>
+                                  <h3 className="font-semibold text-base mb-1 text-muted-foreground">Bail en cours pour ce bien</h3>
+                                  <p className="text-sm text-muted-foreground">
+                                    Vous pourrez créer un nouveau bail 1 mois avant la fin du bail actuel.
+                                  </p>
+                                </div>
+                              </div>
+                            </CardContent>
+                          </Card>
+                        );
+                      }
+
+                      return (
+                        <Card
+                          onClick={() => router.push(`/client/proprietaire/baux/new${selectedPropertyId ? `?propertyId=${selectedPropertyId}` : ""}`)}
+                          className="border-2 border-dashed hover:border-primary hover:bg-primary/5 transition-all cursor-pointer group"
+                        >
+                          <CardContent className="flex flex-col items-center justify-center px-0">
+                            <div className="flex flex-row items-center gap-10 text-center">
+                              <div className="rounded-full bg-primary/10 p-3 group-hover:bg-primary/20 transition-colors">
+                                <Plus className="h-6 w-6 text-primary" />
+                              </div>
+                              <div>
+                                <h3 className="font-semibold text-base mb-1">Démarrer un dossier pour</h3>
+                                <p className="text-sm text-muted-foreground">
+                                  {selectedProperty?.label || selectedProperty?.fullAddress || "Bien sélectionné"}
+                                </p>
+                              </div>
+                            </div>
+                          </CardContent>
+                        </Card>
+                      );
+                    })()}
+
+                    {/* Liste des baux (exclure les DRAFT non payés, déjà affichés au-dessus) */}
+                    {(selectedProperty.bails?.filter((b) => !(b.status === "DRAFT" && !b.paidAt))?.length || 0) > 0 ? (
                       <div className="space-y-3">
-                        {(selectedProperty.bails || []).map((bail) => {
+                        {(selectedProperty.bails || []).filter((b) => !(b.status === "DRAFT" && !b.paidAt)).map((bail) => {
                           const locataire = bail.parties?.find(
                             (p) => p.profilType === ProfilType.LOCATAIRE
                           );
@@ -617,7 +720,7 @@ export function DemandesPageClient({ biens, locataires, ownerId }: DemandesPageC
     
                                   {/* Chips : loyer / type / dates */}
                                   <div className="flex flex-wrap gap-1.5 items-center">
-                                    {bail.rentAmount && (
+                                    {bail.rentAmount != null && bail.rentAmount > 0 && (
                                       <span className="inline-flex items-center gap-1 text-xs font-semibold bg-primary/10 text-primary rounded-full px-2.5 py-1">
                                         <Euro className="h-3 w-3" />
                                         {bail.rentAmount.toLocaleString()} €/mois

--- a/components/client/locataire-baux-client.tsx
+++ b/components/client/locataire-baux-client.tsx
@@ -206,7 +206,6 @@ function BailCard({ bail }: { bail: Bail }) {
           <div className="flex flex-wrap gap-1.5 items-center">
             {bail.rentAmount != null && bail.rentAmount > 0 && (
               <span className="inline-flex items-center gap-1 text-xs font-semibold bg-primary/10 text-primary rounded-full px-2.5 py-1">
-                <Euro className="h-3 w-3" />
                 {bail.rentAmount.toLocaleString()} €/mois
               </span>
             )}

--- a/components/client/locataire-baux-client.tsx
+++ b/components/client/locataire-baux-client.tsx
@@ -73,6 +73,7 @@ const BAIL_STEPS = [
 const BAIL_STEP_INDEX: Record<string, number> = {
   DRAFT: 0,
   AWAITING_TENANT: 0,
+  AWAITING_TENANT_FORM: 0,
   PENDING_VALIDATION: 0,
   READY_FOR_NOTARY: 1,
   CLIENT_CONTACTED: 1,
@@ -83,6 +84,7 @@ const BAIL_STEP_INDEX: Record<string, number> = {
 const BAIL_STATUS_CONFIG: Record<string, { badgeBg: string; label: string; icon: React.ElementType }> = {
   DRAFT: { badgeBg: "bg-blue-50 text-blue-700 border-blue-200", label: "En vérification", icon: Clock },
   AWAITING_TENANT: { badgeBg: "bg-orange-50 text-orange-700 border-orange-200", label: "En attente", icon: Clock },
+  AWAITING_TENANT_FORM: { badgeBg: "bg-indigo-50 text-indigo-700 border-indigo-200", label: "Formulaire à compléter", icon: FileText },
   PENDING_VALIDATION: { badgeBg: "bg-blue-50 text-blue-700 border-blue-200", label: "En vérification", icon: Clock },
   READY_FOR_NOTARY: { badgeBg: "bg-violet-50 text-violet-700 border-violet-200", label: "Chez le notaire", icon: Scale },
   CLIENT_CONTACTED: { badgeBg: "bg-violet-50 text-violet-700 border-violet-200", label: "Chez le notaire", icon: Scale },

--- a/components/client/locataire-baux-client.tsx
+++ b/components/client/locataire-baux-client.tsx
@@ -204,7 +204,7 @@ function BailCard({ bail }: { bail: Bail }) {
 
           {/* Chips */}
           <div className="flex flex-wrap gap-1.5 items-center">
-            {bail.rentAmount && (
+            {bail.rentAmount != null && bail.rentAmount > 0 && (
               <span className="inline-flex items-center gap-1 text-xs font-semibold bg-primary/10 text-primary rounded-full px-2.5 py-1">
                 <Euro className="h-3 w-3" />
                 {bail.rentAmount.toLocaleString()} €/mois

--- a/components/client/owner-bail-card.tsx
+++ b/components/client/owner-bail-card.tsx
@@ -1,0 +1,522 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import {
+  ArrowRight,
+  Calendar,
+  Clock,
+  ExternalLink,
+  FileCheck2,
+  FileText,
+  Home,
+  Loader2,
+  MessageSquare,
+  Store,
+  User,
+  UserPlus,
+} from "lucide-react";
+import { BailFamille, BailType, ProfilType } from "@prisma/client";
+import { toast } from "sonner";
+
+import { createTenantForLease } from "@/lib/actions/leases";
+import { cn } from "@/lib/utils";
+import { calculateBailEndDate } from "@/lib/utils/calculateBailEndDate";
+import { formatDate } from "@/lib/utils/formatters";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { BailChatSheet } from "@/components/client/bail-chat-sheet";
+
+export type OwnerBailCardData = {
+  id: string;
+  bailType?: string | null;
+  bailFamily?: string | null;
+  status: string;
+  rentAmount?: number | null;
+  effectiveDate?: string | Date | null;
+  endDate?: string | Date | null;
+  property: {
+    id: string;
+    label: string | null;
+    fullAddress: string | null;
+  };
+  parties?: Array<{
+    id: string;
+    profilType: string;
+    persons?: Array<{
+      firstName: string | null;
+      lastName: string | null;
+      email?: string | null;
+    }>;
+    entreprise?: {
+      legalName: string | null;
+      name: string | null;
+      email?: string | null;
+    } | null;
+  }>;
+  dossierAssignments?: Array<{
+    id?: string;
+    notaire: {
+      id?: string;
+      name: string | null;
+      email: string | null;
+    } | null;
+  }>;
+};
+
+type OwnerBailCardProps = {
+  bail: OwnerBailCardData;
+  context: "dashboard" | "dossiers";
+  detailHref?: string;
+  onViewDetail?: () => void;
+};
+
+const STEPS = ["Vérification", "Notaire", "Signé"] as const;
+
+const STEP_INDEX: Record<string, number> = {
+  AWAITING_TENANT: 0,
+  AWAITING_TENANT_FORM: 0,
+  PENDING_VALIDATION: 0,
+  READY_FOR_NOTARY: 1,
+  CLIENT_CONTACTED: 1,
+  SIGNED: 2,
+  TERMINATED: 2,
+  DESISTE: 2,
+  CLASSE_SANS_SUITE: 2,
+};
+
+const TERMINAL_STATUSES = ["TERMINATED", "DESISTE", "CLASSE_SANS_SUITE"];
+
+const STATUS_MESSAGES: Record<string, string> = {
+  AWAITING_TENANT_FORM:
+    "En attente des informations du locataire. Le lien lui a bien été envoyé par email.",
+  PENDING_VALIDATION:
+    "Votre dossier est entre nos mains. On revient vers vous sous 48h.",
+  READY_FOR_NOTARY:
+    "Un notaire a pris en charge votre dossier. Il va vous contacter prochainement.",
+  CLIENT_CONTACTED:
+    "Votre dossier avance avec votre notaire. Vous êtes désormais en contact pour préparer ensemble les prochaines étapes jusqu'à la signature.",
+  SIGNED: "Félicitations ! Votre bail a été signé avec succès.",
+  TERMINATED: "Ce bail est terminé.",
+  DESISTE: "Ce dossier a fait l'objet d'un désistement.",
+  CLASSE_SANS_SUITE: "Ce dossier a été classé sans suite.",
+};
+
+const BAIL_TYPE_LABELS: Record<string, string> = {
+  BAIL_NU_3_ANS: "Bail nu 3 ans",
+  BAIL_NU_6_ANS: "Bail nu 6 ans",
+  BAIL_MEUBLE_1_ANS: "Bail meublé 1 an",
+  BAIL_MEUBLE_9_MOIS: "Bail meublé 9 mois",
+};
+
+function formatCurrency(value: number) {
+  return new Intl.NumberFormat("fr-FR", {
+    style: "currency",
+    currency: "EUR",
+    maximumFractionDigits: 0,
+  }).format(value);
+}
+
+function getTenantName(parties: OwnerBailCardData["parties"]) {
+  const tenant = parties?.find((party) => party.profilType === ProfilType.LOCATAIRE);
+  if (!tenant) return null;
+  if (tenant.entreprise) {
+    return tenant.entreprise.legalName || tenant.entreprise.name || "Entreprise";
+  }
+  const person = tenant.persons?.[0];
+  if (!person) return null;
+  return (
+    `${person.firstName || ""} ${person.lastName || ""}`.trim() ||
+    person.email ||
+    null
+  );
+}
+
+function BailTimeline({ status }: { status: string }) {
+  const stepIndex = STEP_INDEX[status] ?? 0;
+  const terminal = TERMINAL_STATUSES.includes(status);
+
+  if (terminal) return null;
+
+  return (
+    <div className="space-y-1.5">
+      <div className="relative">
+        <div className="absolute inset-x-0 top-[5px] h-px bg-border" />
+        <div className="flex justify-between">
+          {STEPS.map((step, index) => {
+            const done = stepIndex > index;
+            const active = stepIndex === index;
+            return (
+              <div
+                key={step}
+                className={cn(
+                  "relative z-10 h-2.5 w-2.5 rounded-full transition-all",
+                  done
+                    ? "bg-primary"
+                    : active
+                      ? "bg-primary ring-[3px] ring-primary/20"
+                      : "bg-border"
+                )}
+              />
+            );
+          })}
+        </div>
+      </div>
+      <div className="relative flex justify-between">
+        {STEPS.map((step, index) => {
+          const done = stepIndex > index;
+          const active = stepIndex === index;
+          const color = active
+            ? "font-semibold text-primary"
+            : done
+              ? "text-primary/50"
+              : "text-muted-foreground/50";
+          return (
+            <p
+              key={step}
+              className={cn(
+                "text-[9px]",
+                index === 1 && "absolute left-1/2 -translate-x-1/2 text-center",
+                index === 2 && "text-right",
+                color
+              )}
+            >
+              {step}
+            </p>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+export function OwnerBailCard({
+  bail,
+  context,
+  detailHref,
+  onViewDetail,
+}: OwnerBailCardProps) {
+  const router = useRouter();
+  const [tenantDialogOpen, setTenantDialogOpen] = useState(false);
+  const [tenantEmail, setTenantEmail] = useState("");
+  const [isAddingTenant, setIsAddingTenant] = useState(false);
+
+  const tenantName = getTenantName(bail.parties);
+  const missingTenant = bail.status === "AWAITING_TENANT" && !tenantName;
+  const notaire = bail.dossierAssignments?.[0]?.notaire ?? null;
+  const isCommercial = bail.bailFamily === BailFamille.COMMERCIAL;
+  const isSigned = bail.status === "SIGNED";
+  const isContacted = bail.status === "CLIENT_CONTACTED";
+  const terminal = TERMINAL_STATUSES.includes(bail.status);
+  const familyLabel = isCommercial ? "Bail commercial" : "Bail d'habitation";
+  const propertyLabel =
+    bail.property.label ||
+    bail.property.fullAddress?.split(",")[0] ||
+    "Bien immobilier";
+  const propertyDescription =
+    bail.property.label && bail.property.fullAddress
+      ? `${bail.property.label} — ${bail.property.fullAddress}`
+      : bail.property.fullAddress || propertyLabel;
+  const tenantInitial =
+    tenantName?.split(" ").filter(Boolean).map((part) => part[0]).join("").slice(0, 2).toUpperCase() ||
+    "?";
+
+  const calculatedEndDate =
+    bail.endDate ||
+    (bail.effectiveDate && bail.bailType
+      ? calculateBailEndDate(
+          new Date(bail.effectiveDate),
+          bail.bailType as BailType
+        )
+      : null);
+
+  const message = STATUS_MESSAGES[bail.status];
+  const showChat = Boolean(notaire);
+
+  const handleAddTenant = async () => {
+    if (!tenantEmail.includes("@")) {
+      toast.error("Email invalide");
+      return;
+    }
+    try {
+      setIsAddingTenant(true);
+      await createTenantForLease({ bailId: bail.id, email: tenantEmail });
+      toast.success("Locataire ajouté — un email lui a été envoyé");
+      setTenantDialogOpen(false);
+      setTenantEmail("");
+      router.refresh();
+    } catch (error: any) {
+      toast.error("Erreur", { description: error.message });
+    } finally {
+      setIsAddingTenant(false);
+    }
+  };
+
+  const detailAction = detailHref ? (
+    <Button
+      asChild
+      size="sm"
+      variant="ghost"
+      className={cn(
+        "gap-1.5 text-primary hover:bg-primary/5 hover:text-primary/80",
+        !showChat && "w-full"
+      )}
+    >
+      <Link href={detailHref}>
+        <ExternalLink className="h-3.5 w-3.5" />
+        Voir le dossier
+      </Link>
+    </Button>
+  ) : (
+    <Button
+      type="button"
+      size="sm"
+      variant="ghost"
+      className={cn(
+        "gap-1.5 text-primary hover:bg-primary/5 hover:text-primary/80",
+        !showChat && "w-full"
+      )}
+      onClick={onViewDetail}
+    >
+      <ExternalLink className="h-3.5 w-3.5" />
+      Voir le dossier
+    </Button>
+  );
+
+  return (
+    <>
+      <Card
+        className={cn(
+          "overflow-hidden border pt-0 pb-0 shadow-sm transition-shadow hover:shadow-md",
+          isSigned && "ring-1 ring-green-300",
+          isContacted && "ring-1 ring-blue-400"
+        )}
+      >
+        <CardContent className="p-0">
+          <div className="space-y-3.5 p-4">
+            <div className="flex items-start gap-2 min-w-0">
+              <div
+                className={cn(
+                  "mt-0.5 shrink-0 rounded-md p-1.5",
+                  isSigned
+                    ? "bg-green-100 text-green-700 dark:bg-green-950 dark:text-green-400"
+                    : isCommercial
+                      ? "bg-amber-100 text-amber-700 dark:bg-amber-950 dark:text-amber-400"
+                      : "bg-blue-100 text-blue-700 dark:bg-blue-950 dark:text-blue-400"
+                )}
+              >
+                {isSigned ? (
+                  <FileCheck2 className="h-3.5 w-3.5" />
+                ) : isCommercial ? (
+                  <Store className="h-3.5 w-3.5" />
+                ) : (
+                  <Home className="h-3.5 w-3.5" />
+                )}
+              </div>
+              <div className="min-w-0">
+                <p className="text-sm font-semibold leading-tight">{familyLabel}</p>
+                {context === "dashboard" && (
+                  <p
+                    className="mt-0.5 truncate text-xs text-muted-foreground"
+                    title={propertyDescription}
+                  >
+                    {propertyDescription}
+                  </p>
+                )}
+              </div>
+            </div>
+
+            <div className="flex flex-wrap items-center gap-1.5">
+              {bail.rentAmount != null && bail.rentAmount > 0 && (
+                <span className="inline-flex items-center rounded-full bg-primary/10 px-2.5 py-1 text-xs font-semibold text-primary">
+                  {formatCurrency(bail.rentAmount)}/mois
+                </span>
+              )}
+              {bail.bailType && (
+                <span className="inline-flex items-center gap-1 rounded-full bg-muted px-2.5 py-1 text-xs text-muted-foreground">
+                  <FileText className="h-3 w-3" />
+                  {BAIL_TYPE_LABELS[bail.bailType] || bail.bailType}
+                </span>
+              )}
+              {bail.effectiveDate && (
+                <span className="inline-flex items-center gap-1 rounded-full bg-muted px-2.5 py-1 text-xs text-muted-foreground">
+                  <Calendar className="h-3 w-3" />
+                  {formatDate(bail.effectiveDate)}
+                  {calculatedEndDate && (
+                    <>
+                      <ArrowRight className="h-2.5 w-2.5 shrink-0" />
+                      {formatDate(calculatedEndDate)}
+                    </>
+                  )}
+                </span>
+              )}
+            </div>
+
+            {missingTenant ? (
+              <div className="flex items-center justify-between gap-3 rounded-lg border border-blue-200 bg-blue-50 px-3 py-2.5 dark:border-blue-800 dark:bg-blue-950/40">
+                <div className="flex min-w-0 items-center gap-2">
+                  <div className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-blue-100 text-blue-700 dark:bg-blue-900 dark:text-blue-300">
+                    <User className="h-3 w-3" />
+                  </div>
+                  <div className="min-w-0">
+                    <span className="block text-[10px] font-medium uppercase tracking-wide text-blue-700 dark:text-blue-300">
+                      Locataire
+                    </span>
+                    <span className="block text-xs italic text-blue-700 dark:text-blue-300">
+                      Non renseigné
+                    </span>
+                    <span className="block text-[9px] leading-tight text-blue-700 dark:text-blue-300">
+                      Vous pouvez l&apos;ajouter dès que vous l&apos;avez trouvé.
+                    </span>
+                  </div>
+                </div>
+                <Button
+                  type="button"
+                  size="sm"
+                  className="h-8 shrink-0 bg-blue-700 px-2.5 text-xs text-white hover:bg-blue-800"
+                  onClick={() => setTenantDialogOpen(true)}
+                >
+                  <UserPlus className="mr-1 h-3.5 w-3.5" />
+                  Ajouter
+                </Button>
+              </div>
+            ) : (
+              <div className="flex items-center gap-2">
+                <div className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-primary/20 text-xs font-semibold text-primary">
+                  {tenantName ? tenantInitial : <User className="h-3 w-3 text-muted-foreground" />}
+                </div>
+                <div className="flex min-w-0 flex-col">
+                  <span className="mb-0.5 text-[10px] font-medium uppercase leading-none tracking-wide text-muted-foreground">
+                    Locataire
+                  </span>
+                  <span
+                    className={cn(
+                      "truncate text-sm",
+                      !tenantName && "text-xs italic text-muted-foreground"
+                    )}
+                  >
+                    {tenantName ?? "Non renseigné"}
+                  </span>
+                </div>
+              </div>
+            )}
+
+            <BailTimeline status={bail.status} />
+
+            {message && (
+              <div
+                className={cn(
+                  "flex items-start gap-2 rounded-lg px-3 py-2 text-xs sm:text-sm",
+                  isSigned
+                    ? "bg-green-50 text-green-800 dark:bg-green-950/60 dark:text-green-200"
+                    : isContacted
+                      ? "bg-blue-50 text-blue-800 dark:bg-blue-950/60 dark:text-blue-200"
+                      : "bg-muted/70 text-muted-foreground"
+                )}
+              >
+                {isSigned ? (
+                  <FileCheck2 className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+                ) : isContacted ? (
+                  <MessageSquare className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+                ) : terminal ? (
+                  <FileText className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+                ) : (
+                  <Clock className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+                )}
+                <span className="leading-snug">{message}</span>
+              </div>
+            )}
+          </div>
+
+          <div className="flex items-center gap-2 border-t bg-muted/30 px-4 py-3">
+            {showChat && (
+              <BailChatSheet
+                bailId={bail.id}
+                trigger={
+                  <Button size="sm" className="flex-1 gap-1.5">
+                    <MessageSquare className="h-3.5 w-3.5" />
+                    Contacter le notaire
+                  </Button>
+                }
+              />
+            )}
+            <div className={cn(!showChat && "w-full", showChat && "shrink-0")}>
+              {detailAction}
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Dialog open={tenantDialogOpen} onOpenChange={setTenantDialogOpen}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2">
+              <UserPlus className="h-5 w-5" />
+              Ajouter un locataire
+            </DialogTitle>
+            <DialogDescription>
+              Entrez l&apos;adresse email de votre locataire. Il recevra un lien pour compléter son dossier.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-2 py-2">
+            <Label>Email *</Label>
+            <Input
+              type="email"
+              placeholder="locataire@example.com"
+              value={tenantEmail}
+              onChange={(event) => setTenantEmail(event.target.value)}
+              disabled={isAddingTenant}
+              inputMode="email"
+              autoComplete="email"
+              className="h-11"
+              onKeyDown={(event) => {
+                if (event.key === "Enter") handleAddTenant();
+              }}
+            />
+          </div>
+          <DialogFooter className="flex-col gap-2 sm:flex-col">
+            <Button
+              onClick={handleAddTenant}
+              disabled={isAddingTenant || !tenantEmail}
+              className="w-full"
+            >
+              {isAddingTenant ? (
+                <>
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  Ajout en cours...
+                </>
+              ) : (
+                <>
+                  <UserPlus className="mr-2 h-4 w-4" />
+                  Ajouter le locataire
+                </>
+              )}
+            </Button>
+            <Button
+              variant="outline"
+              onClick={() => {
+                setTenantDialogOpen(false);
+                setTenantEmail("");
+              }}
+              disabled={isAddingTenant}
+              className="w-full"
+            >
+              Annuler
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/components/client/owner-progress-card.tsx
+++ b/components/client/owner-progress-card.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import Link from "next/link";
+import { AlertCircle, ClipboardList, Trash2, User } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+
+type OwnerProgressCardProps = {
+  propertyLabel: string | null;
+  tenantName?: string | null;
+  bailTypeLabel?: string | null;
+  message: string;
+  continueHref: string;
+  continueLabel?: string;
+  onDelete?: () => void;
+  deleting?: boolean;
+};
+
+export function OwnerProgressCard({
+  propertyLabel,
+  tenantName,
+  bailTypeLabel,
+  message,
+  continueHref,
+  continueLabel = "Continuer ma demande",
+  onDelete,
+  deleting = false,
+}: OwnerProgressCardProps) {
+  return (
+    <Card className="border-amber-200 bg-amber-50/40 transition-all hover:shadow-md dark:border-amber-800 dark:bg-amber-950/20">
+      <CardContent className="p-4 sm:p-5">
+        <div className="flex min-w-0 items-start gap-2.5">
+          <div className="mt-0.5 shrink-0 rounded-full bg-amber-100 p-1.5 dark:bg-amber-900 sm:p-2">
+            <ClipboardList className="h-3.5 w-3.5 text-amber-600 dark:text-amber-400 sm:h-4 sm:w-4" />
+          </div>
+          <div className="min-w-0 flex-1">
+            <p className="text-sm font-semibold leading-tight text-amber-900 dark:text-amber-200 sm:text-base">
+              Demande de bail en cours
+            </p>
+            {propertyLabel ? (
+              <p className="mt-0.5 truncate text-xs text-amber-700 dark:text-amber-400">
+                {propertyLabel}
+              </p>
+            ) : (
+              <p className="mt-0.5 text-xs italic text-amber-600/70 dark:text-amber-500">
+                Bien non renseigné
+              </p>
+            )}
+            {tenantName && (
+              <div className="mt-0.5 flex items-center gap-1">
+                <User className="h-3 w-3 shrink-0 text-amber-600/70 dark:text-amber-500" />
+                <p className="truncate text-[11px] text-amber-600/80 dark:text-amber-500">
+                  {tenantName}
+                </p>
+              </div>
+            )}
+            {bailTypeLabel && (
+              <p className="mt-0.5 text-[11px] text-amber-600/80 dark:text-amber-500">
+                {bailTypeLabel}
+              </p>
+            )}
+          </div>
+        </div>
+
+        <div className="mt-3 flex items-start gap-2 rounded-lg bg-amber-100/60 px-3 py-2 text-xs text-amber-800 dark:bg-amber-900/30 dark:text-amber-300 sm:text-sm">
+          <AlertCircle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+          <span className="leading-snug">{message}</span>
+        </div>
+
+        <div className="mt-3 flex items-center gap-2">
+          <Button
+            asChild
+            size="sm"
+            variant="outline"
+            className="border-amber-300 text-amber-800 hover:bg-amber-100 dark:border-amber-700 dark:text-amber-300"
+          >
+            <Link href={continueHref}>{continueLabel}</Link>
+          </Button>
+          {onDelete && (
+            <Button
+              type="button"
+              size="sm"
+              variant="ghost"
+              onClick={onDelete}
+              disabled={deleting}
+              className="h-8 px-2 text-amber-700 hover:text-destructive dark:text-amber-400"
+            >
+              <Trash2 className="mr-1 h-3.5 w-3.5" />
+              Supprimer
+            </Button>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/client/unified-status-list.tsx
+++ b/components/client/unified-status-list.tsx
@@ -86,8 +86,9 @@ type UnifiedItem = {
 
 const statusColors: Record<BailStatus, string> = {
   DRAFT: "bg-gray-100 text-gray-800",
-  AWAITING_TENANT: "bg-orange-100 text-orange-800",
-  PENDING_VALIDATION: "bg-orange-100 text-orange-800",
+  AWAITING_TENANT: "bg-violet-100 text-violet-800",
+  AWAITING_TENANT_FORM: "bg-indigo-100 text-indigo-800",
+  PENDING_VALIDATION: "bg-amber-100 text-amber-800",
   READY_FOR_NOTARY: "bg-blue-100 text-blue-800",
   CLIENT_CONTACTED: "bg-purple-100 text-purple-800",
   SIGNED: "bg-green-100 text-green-800",

--- a/components/dashboard/bails-list-dashboard.tsx
+++ b/components/dashboard/bails-list-dashboard.tsx
@@ -153,10 +153,14 @@ export function BailsListDashboard({ bails: initialBails }: BailsListDashboardPr
   const bailStatusOptions: Array<{ value: BailStatus | "all"; label: string; icon: React.ReactNode; colorClasses?: string }> = [
     { value: "all", label: "Tous les statuts", icon: null },
     { value: "DRAFT", label: "Brouillon", icon: <FileText className="h-4 w-4" /> },
+    { value: "AWAITING_TENANT", label: "Attente locataire", icon: <FileText className="h-4 w-4" /> },
+    { value: "AWAITING_TENANT_FORM", label: "Attente formulaire locataire", icon: <FileText className="h-4 w-4" /> },
     { value: "PENDING_VALIDATION", label: "En validation", icon: <CircleDot className="h-4 w-4" /> },
     { value: "READY_FOR_NOTARY", label: "Prêt pour notaire", icon: <CheckCircle2Icon className="h-4 w-4" /> },
     { value: "SIGNED", label: "Signé", icon: <CheckCircle2Icon className="h-4 w-4" /> },
     { value: "TERMINATED", label: "Terminé", icon: <FileText className="h-4 w-4" /> },
+    { value: "DESISTE", label: "Désisté", icon: <FileText className="h-4 w-4" /> },
+    { value: "CLASSE_SANS_SUITE", label: "Classé sans suite", icon: <FileText className="h-4 w-4" /> },
   ];
 
   return (

--- a/components/intakes/payment-step.tsx
+++ b/components/intakes/payment-step.tsx
@@ -220,7 +220,11 @@ export function PaymentStep({
     })
       .then((r) => r.json())
       .then((data) => {
-        if (data.clientSecret) {
+        if (data.alreadyPaid && data.paymentIntentId) {
+          // Le paiement a déjà réussi (ex: retry après échec de soumission)
+          // Poursuivre directement la soumission sans repayer
+          onPaymentSuccess(data.paymentIntentId);
+        } else if (data.clientSecret) {
           setClientSecret(data.clientSecret);
         } else {
           setLoadError(

--- a/components/intakes/tenant-intake-form.tsx
+++ b/components/intakes/tenant-intake-form.tsx
@@ -1882,7 +1882,7 @@ export function TenantIntakeForm({ intakeLink: initialIntakeLink }: { intakeLink
             <AccordionContent className="px-4 pt-4 space-y-6">
               {/* Informations financières mises en avant */}
               <div className="grid gap-4 grid-cols-2">
-                {bail.rentAmount && (
+                {bail.rentAmount != null && bail.rentAmount > 0 && (
                   <div className="bg-primary/5 rounded-lg p-4 border-2 border-primary/20">
                     <div className="flex items-center gap-2 mb-2">
                       <Euro className="h-4 w-4 text-primary" />

--- a/components/leases/bail-status-multi-select.tsx
+++ b/components/leases/bail-status-multi-select.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import * as React from "react";
-import { Check, ChevronsUpDown, X, FileText, CircleDot, CheckCircle2 } from "lucide-react";
+import { Check, ChevronsUpDown, X, FileText, CircleDot, CheckCircle2, Home, XCircle } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import {
@@ -33,6 +33,16 @@ const statusOptions: BailStatusOption[] = [
     icon: <FileText className="h-4 w-4" />,
   },
   {
+    value: "AWAITING_TENANT",
+    label: "Attente locataire",
+    icon: <Home className="h-4 w-4" />,
+  },
+  {
+    value: "AWAITING_TENANT_FORM",
+    label: "Attente formulaire locataire",
+    icon: <FileText className="h-4 w-4" />,
+  },
+  {
     value: "PENDING_VALIDATION",
     label: "En validation",
     icon: <CircleDot className="h-4 w-4" />,
@@ -50,6 +60,16 @@ const statusOptions: BailStatusOption[] = [
   {
     value: "TERMINATED",
     label: "Terminé",
+    icon: <FileText className="h-4 w-4" />,
+  },
+  {
+    value: "DESISTE",
+    label: "Désisté",
+    icon: <XCircle className="h-4 w-4" />,
+  },
+  {
+    value: "CLASSE_SANS_SUITE",
+    label: "Classé sans suite",
     icon: <FileText className="h-4 w-4" />,
   },
 ];

--- a/components/notifications/notifications-list.tsx
+++ b/components/notifications/notifications-list.tsx
@@ -65,6 +65,12 @@ function getNotificationMessage(notification: Notification): string {
         if (metadata.oldStatus === BailStatus.DRAFT && metadata.newStatus === BailStatus.PENDING_VALIDATION) {
           return "Bail en attente de validation par bailnotarie";
         }
+        if (metadata.oldStatus === BailStatus.AWAITING_TENANT_FORM && metadata.newStatus === BailStatus.PENDING_VALIDATION) {
+          return "Formulaire locataire soumis — bail en attente de validation";
+        }
+        if (metadata.oldStatus === BailStatus.AWAITING_TENANT && metadata.newStatus === BailStatus.AWAITING_TENANT_FORM) {
+          return "Locataire ajouté — en attente de son formulaire";
+        }
         if (metadata.oldStatus === BailStatus.PENDING_VALIDATION && metadata.newStatus === BailStatus.READY_FOR_NOTARY) {
           return "Bail prêt a être assigné au notaire";
         }

--- a/components/shared/status-badge.tsx
+++ b/components/shared/status-badge.tsx
@@ -71,13 +71,23 @@ export function StatusBadge({ status, className }: StatusBadgeProps) {
       icon: <XCircle className="size-4" />
     },
     // BailStatus
-    DRAFT: { 
-      variant: "outline", 
+    DRAFT: {
+      variant: "outline",
       label: "Brouillon",
       icon: <FileText className="size-4" />
     },
-    PENDING_VALIDATION: { 
-      variant: "secondary", 
+    AWAITING_TENANT: {
+      variant: "secondary",
+      label: "En attente du locataire",
+      icon: <Home className="size-4" />
+    },
+    AWAITING_TENANT_FORM: {
+      variant: "secondary",
+      label: "Formulaire locataire en attente",
+      icon: <FileText className="size-4" />
+    },
+    PENDING_VALIDATION: {
+      variant: "secondary",
       label: "En cours de validation",
       icon: <CircleDot className="size-4" />
     },

--- a/lib/actions/client-space.ts
+++ b/lib/actions/client-space.ts
@@ -284,6 +284,7 @@ export async function getClientProperties(clientId: string) {
           rentAmount: true,
           bailType: true,
           bailFamily: true,
+          paidAt: true,
           parties: {
             select: {
               id: true,
@@ -315,6 +316,15 @@ export async function getClientProperties(clientId: string) {
                   email: true,
                 },
               },
+            },
+            take: 1,
+          },
+          intakes: {
+            where: { target: "OWNER" },
+            select: {
+              id: true,
+              token: true,
+              status: true,
             },
             take: 1,
           },

--- a/lib/actions/client-space.ts
+++ b/lib/actions/client-space.ts
@@ -348,9 +348,11 @@ export async function getProprietaireStats(clientId: string) {
     totalBaux: bails.length,
     bauxActifs: bails.filter((b: SerializedBail) => b.status === BailStatus.SIGNED).length,
     bauxTermines: bails.filter((b: SerializedBail) => b.status === BailStatus.TERMINATED).length,
-    bauxEnCours: bails.filter((b: SerializedBail) => 
-      b.status === BailStatus.DRAFT || 
-      b.status === BailStatus.PENDING_VALIDATION || 
+    bauxEnCours: bails.filter((b: SerializedBail) =>
+      b.status === BailStatus.DRAFT ||
+      b.status === BailStatus.AWAITING_TENANT ||
+      b.status === BailStatus.AWAITING_TENANT_FORM ||
+      b.status === BailStatus.PENDING_VALIDATION ||
       b.status === BailStatus.READY_FOR_NOTARY
     ).length,
   };
@@ -368,9 +370,9 @@ export async function getLocataireStats(clientId: string) {
     totalBaux: bails.length,
     bauxActifs: bails.filter((b: SerializedBail) => b.status === BailStatus.SIGNED).length,
     bauxTermines: bails.filter((b: SerializedBail) => b.status === BailStatus.TERMINATED).length,
-    bauxEnCours: bails.filter((b: SerializedBail) => 
-      b.status === BailStatus.DRAFT || 
-      b.status === BailStatus.PENDING_VALIDATION || 
+    bauxEnCours: bails.filter((b: SerializedBail) =>
+      b.status === BailStatus.AWAITING_TENANT_FORM ||
+      b.status === BailStatus.PENDING_VALIDATION ||
       b.status === BailStatus.READY_FOR_NOTARY
     ).length,
   };

--- a/lib/actions/clients.ts
+++ b/lib/actions/clients.ts
@@ -9,7 +9,7 @@ import {
   createTenantBasicClientSchema,
   ownerFormSchema,
   tenantFormSchema,
-  updateClientSchema
+  updateClientSchema,
 } from "@/lib/zod/client";
 import { revalidatePath } from "next/cache";
 import { Decimal } from "@prisma/client/runtime/library";
@@ -574,7 +574,7 @@ export async function createFullClient(data: unknown) {
 }
 
 // Soumettre le formulaire propriétaire (crée bien, bail, locataire et envoie email)
-export async function submitOwnerForm(data: unknown) {
+export async function submitOwnerForm(data: unknown, paymentIntentId?: string) {
   let validated;
   try {
     validated = ownerFormSchema.parse(data);
@@ -1026,35 +1026,39 @@ export async function submitOwnerForm(data: unknown) {
     const updateData: any = {
       bailType: validated.bailType || BailType.BAIL_NU_3_ANS,
       bailFamily: validated.bailFamily || BailFamille.HABITATION,
-      status: tenant ? BailStatus.DRAFT : BailStatus.AWAITING_TENANT,
+      status: tenant ? BailStatus.AWAITING_TENANT_FORM : BailStatus.AWAITING_TENANT,
       rentAmount: validated.bailRentAmount,
       monthlyCharges: validated.bailMonthlyCharges || 0,
       securityDeposit: validated.bailSecurityDeposit || 0,
       effectiveDate: validated.bailEffectiveDate,
       endDate: validated.bailEndDate,
       paymentDay: validated.bailPaymentDay,
+      ...(paymentIntentId && {
+        stripePaymentIntentId: paymentIntentId,
+        paidAt: new Date(),
+      }),
     };
-    
+
     // Connecter le locataire seulement s'il existe et n'est pas déjà connecté
     if (tenant && !isTenantConnected) {
       updateData.parties = {
         connect: bailParties,
       };
     }
-    
+
     // Mettre à jour le bail existant
     bail = await prisma.bail.update({
       where: { id: ownerIntakeLink.bailId },
       data: updateData,
     });
-    
+
   } else {
     // Créer un nouveau bail
     bail = await prisma.bail.create({
       data: {
         bailType: validated.bailType || BailType.BAIL_NU_3_ANS,
         bailFamily: validated.bailFamily || BailFamille.HABITATION,
-        status: tenant ? BailStatus.DRAFT : BailStatus.AWAITING_TENANT,
+        status: tenant ? BailStatus.AWAITING_TENANT_FORM : BailStatus.AWAITING_TENANT,
         rentAmount: validated.bailRentAmount,
         monthlyCharges: validated.bailMonthlyCharges || 0,
         securityDeposit: validated.bailSecurityDeposit || 0,
@@ -1062,6 +1066,10 @@ export async function submitOwnerForm(data: unknown) {
         endDate: validated.bailEndDate,
         paymentDay: validated.bailPaymentDay,
         propertyId: property.id,
+        ...(paymentIntentId && {
+          stripePaymentIntentId: paymentIntentId,
+          paidAt: new Date(),
+        }),
         parties: {
           connect: bailParties,
         },
@@ -3170,7 +3178,7 @@ export async function updateClientCompletionStatus(data: { id: string; completio
   const bails = await prisma.bail.findMany({
     where: {
       parties: { some: { id } },
-      status: { in: ["DRAFT", "PENDING_VALIDATION"] }
+      status: { in: ["DRAFT", "AWAITING_TENANT_FORM", "PENDING_VALIDATION"] }
     },
     include: {
       property: true,
@@ -3199,12 +3207,12 @@ export async function updateClientCompletionStatus(data: { id: string; completio
       tenantStatus === "PENDING_CHECK" && 
       property.completionStatus === "PENDING_CHECK";
 
-    if (allCompleted && (bail.status === "DRAFT" || bail.status === "PENDING_VALIDATION")) {
+    if (allCompleted && (bail.status === "DRAFT" || bail.status === "AWAITING_TENANT_FORM" || bail.status === "PENDING_VALIDATION")) {
       await prisma.bail.update({
         where: { id: bail.id },
         data: { status: "READY_FOR_NOTARY" }
       });
-    } else if (allPendingCheck && bail.status === "DRAFT") {
+    } else if (allPendingCheck && (bail.status === "DRAFT" || bail.status === "AWAITING_TENANT_FORM")) {
       await prisma.bail.update({
         where: { id: bail.id },
         data: { status: "PENDING_VALIDATION" }

--- a/lib/actions/clients.ts
+++ b/lib/actions/clients.ts
@@ -12,6 +12,7 @@ import {
   updateClientSchema,
 } from "@/lib/zod/client";
 import { revalidatePath } from "next/cache";
+import { after } from "next/server";
 import { Decimal } from "@prisma/client/runtime/library";
 import { ClientType, ProfilType, FamilyStatus, MatrimonialRegime, BailType, BailFamille, BailStatus, PropertyStatus, CompletionStatus } from "@prisma/client";
 import { 
@@ -1202,10 +1203,8 @@ export async function submitOwnerForm(data: unknown, paymentIntentId?: string) {
     console.error("Erreur lors du déclenchement des calculs de statut:", error);
   });
 
-  // Déclencher l'envoi d'email et les notifications en arrière-plan (après le return, ne bloque pas le rendu)
-  Promise.resolve().then(async () => {
+  after(async () => {
     try {
-      // Récupérer les informations du client pour l'email de confirmation
       const clientData = await prisma.client.findUnique({
         where: { id: validated.clientId },
         include: {
@@ -1217,7 +1216,6 @@ export async function submitOwnerForm(data: unknown, paymentIntentId?: string) {
         },
       });
 
-      // Envoyer l'email de confirmation au propriétaire
       if (clientData) {
         let firstName = "";
         let lastName = "";
@@ -1252,7 +1250,6 @@ export async function submitOwnerForm(data: unknown, paymentIntentId?: string) {
         }
       }
 
-      // Notification pour soumission d'intake
       if (ownerIntakeLinkId) {
         await createNotificationForAllUsers(
           NotificationType.INTAKE_SUBMITTED,
@@ -1263,11 +1260,8 @@ export async function submitOwnerForm(data: unknown, paymentIntentId?: string) {
         );
       }
     } catch (error: any) {
-      // Ne pas bloquer la soumission même si les notifications/emails échouent
       console.error("❌ Erreur lors des notifications/emails (en arrière-plan):", error);
     }
-  }).catch((error) => {
-    console.error("❌ Erreur lors de l'exécution asynchrone des notifications/emails:", error);
   });
 
   return result;
@@ -1649,10 +1643,8 @@ export async function submitTenantForm(data: unknown) {
   // Retourner le résultat AVANT les autres notifications pour que l'utilisateur voie le statut immédiatement
   const result = { success: true };
 
-  // Déclencher les notifications et l'email de confirmation en arrière-plan (après le return, ne bloque pas le rendu)
-  Promise.resolve().then(async () => {
-    try {    
-      // Récupérer les informations du client pour l'email de confirmation
+  after(async () => {
+    try {
       const clientData = await prisma.client.findUnique({
         where: { id: validated.clientId },
         include: {
@@ -1664,7 +1656,6 @@ export async function submitTenantForm(data: unknown) {
         },
       });
 
-      // Envoyer l'email de confirmation au locataire
       if (clientData) {
         let firstName = "";
         let lastName = "";
@@ -1697,25 +1688,20 @@ export async function submitTenantForm(data: unknown) {
             console.error("Erreur lors de l'envoi de l'email de confirmation au locataire:", error);
           }
         }
-
       }
 
-      // Notification pour soumission d'intake via formulaire
       if (updatedIntakeLinkId) {
         await createNotificationForAllUsers(
           NotificationType.INTAKE_SUBMITTED,
           "INTAKE",
           updatedIntakeLinkId,
-          null, // Soumis par formulaire, pas par un utilisateur
+          null,
           { intakeTarget: "TENANT"}
         );
       }
     } catch (error: any) {
-      // Ne pas bloquer la soumission même si les notifications échouent
       console.error("❌ Erreur lors des notifications (en arrière-plan):", error);
     }
-  }).catch((error) => {
-    console.error("❌ Erreur lors de l'exécution asynchrone des notifications:", error);
   });
 
   return result;

--- a/lib/actions/intakes.ts
+++ b/lib/actions/intakes.ts
@@ -244,24 +244,8 @@ export async function submitIntake(data: unknown) {
       });
       // Les fichiers sont maintenant uploadés directement via FileUpload avec upload direct client → S3
       // Plus besoin de passer formData
-      await submitOwnerForm(ownerData);
-
-      // Enregistrer le paiement sur le Bail (source de vérité unique)
-      if (paymentIntentId) {
-        const updatedIntakeLink = await prisma.intakeLink.findUnique({
-          where: { token },
-          select: { bailId: true },
-        });
-        if (updatedIntakeLink?.bailId) {
-          await prisma.bail.update({
-            where: { id: updatedIntakeLink.bailId },
-            data: {
-              stripePaymentIntentId: paymentIntentId,
-              paidAt: new Date(),
-            },
-          });
-        }
-      }
+      // On passe paymentIntentId pour que paidAt soit écrit atomiquement avec le bail
+      await submitOwnerForm(ownerData, paymentIntentId || undefined);
 
       return { success: true };
     } catch (error: any) {

--- a/lib/actions/leases.ts
+++ b/lib/actions/leases.ts
@@ -72,7 +72,7 @@ export async function createLease(data: unknown, paymentIntentId?: string, draft
 
   // Statut déterminé server-side selon la présence du locataire
   const finalStatus: BailStatus = validated.tenantId
-    ? BailStatus.DRAFT
+    ? BailStatus.AWAITING_TENANT_FORM
     : BailStatus.AWAITING_TENANT;
 
   if (draftBailId) {
@@ -766,7 +766,7 @@ export async function createTenantForLease(data: unknown) {
     where: { id: validated.bailId },
     data: {
       parties: { connect: { id: tenant.id } },
-      ...(bail.status === BailStatus.AWAITING_TENANT && { status: BailStatus.PENDING_VALIDATION }),
+      ...(bail.status === BailStatus.AWAITING_TENANT && { status: BailStatus.AWAITING_TENANT_FORM }),
     },
   });
 

--- a/lib/actions/properties.ts
+++ b/lib/actions/properties.ts
@@ -543,7 +543,7 @@ export async function updatePropertyCompletionStatus(data: { id: string; complet
   const bails = await prisma.bail.findMany({
     where: {
       propertyId: id,
-      status: { in: ["DRAFT", "PENDING_VALIDATION"] }
+      status: { in: ["DRAFT", "AWAITING_TENANT_FORM", "PENDING_VALIDATION"] }
     },
     include: {
       property: true,
@@ -568,12 +568,12 @@ export async function updatePropertyCompletionStatus(data: { id: string; complet
       tenant.completionStatus === "PENDING_CHECK" && 
       completionStatus === "PENDING_CHECK";
 
-    if (allCompleted && (bail.status === "DRAFT" || bail.status === "PENDING_VALIDATION")) {
+    if (allCompleted && (bail.status === "DRAFT" || bail.status === "AWAITING_TENANT_FORM" || bail.status === "PENDING_VALIDATION")) {
       await prisma.bail.update({
         where: { id: bail.id },
         data: { status: "READY_FOR_NOTARY" }
       });
-    } else if (allPendingCheck && bail.status === "DRAFT") {
+    } else if (allPendingCheck && (bail.status === "DRAFT" || bail.status === "AWAITING_TENANT_FORM")) {
       await prisma.bail.update({
         where: { id: bail.id },
         data: { status: "PENDING_VALIDATION" }

--- a/lib/inngest/helpers.ts
+++ b/lib/inngest/helpers.ts
@@ -37,7 +37,7 @@ export async function triggerContactNotificationEmail(data: {
  * Déclenche l'envoi d'un email de notification
  */
 export async function triggerNotificationEmail(data: {
-  to: string;
+  to: string | string[];
   userName: string | null;
   notificationMessage: string;
   interfaceUrl: string;

--- a/lib/utils/bails-labels.ts
+++ b/lib/utils/bails-labels.ts
@@ -12,6 +12,7 @@ export function getBailTypeLabel(bailType: string): string {
 const bailStatusLabels: Record<string, string> = {
   DRAFT: "Brouillon",
   AWAITING_TENANT: "En attente du locataire",
+  AWAITING_TENANT_FORM: "En attente du formulaire locataire",
   PENDING_VALIDATION: "En attente de validation",
   READY_FOR_NOTARY: "À contacter",
   CLIENT_CONTACTED: "En traitement",
@@ -56,6 +57,21 @@ export const BAIL_STATUS_COLORS: Record<string, {
   text: string;
   label: string;
 }> = {
+  AWAITING_TENANT: {
+    badge: "bg-violet-100 text-violet-700 dark:bg-violet-950 dark:text-violet-400 border-violet-200 dark:border-violet-800",
+    text: "text-violet-600",
+    label: "En attente du locataire",
+  },
+  AWAITING_TENANT_FORM: {
+    badge: "bg-indigo-100 text-indigo-700 dark:bg-indigo-950 dark:text-indigo-400 border-indigo-200 dark:border-indigo-800",
+    text: "text-indigo-600",
+    label: "En attente du formulaire locataire",
+  },
+  PENDING_VALIDATION: {
+    badge: "bg-amber-100 text-amber-700 dark:bg-amber-950 dark:text-amber-400 border-amber-200 dark:border-amber-800",
+    text: "text-amber-600",
+    label: "En attente de validation",
+  },
   READY_FOR_NOTARY: {
     badge: "bg-orange-100 text-orange-700 dark:bg-orange-950 dark:text-orange-400 border-orange-200 dark:border-orange-800",
     text: "text-orange-600",

--- a/lib/utils/completion-status.ts
+++ b/lib/utils/completion-status.ts
@@ -652,7 +652,7 @@ async function checkAndUpdateBailStatus(bail: any): Promise<void> {
 
   // Si tous sont COMPLETED → passer à READY_FOR_NOTARY
   if (ownerCompleted && tenantCompleted && propertyCompleted) {
-    if (bail.status === BailStatus.DRAFT || bail.status === BailStatus.PENDING_VALIDATION) {
+    if (bail.status === BailStatus.DRAFT || bail.status === BailStatus.AWAITING_TENANT_FORM || bail.status === BailStatus.PENDING_VALIDATION) {
       const oldStatus = bail.status;
       await prisma.bail.update({
         where: { id: bail.id },
@@ -675,7 +675,7 @@ async function checkAndUpdateBailStatus(bail: any): Promise<void> {
   }
 
   // Si tous sont PENDING_CHECK et le bail est en DRAFT → passer à PENDING_VALIDATION
-  if (ownerPendingCheck && tenantPendingCheck && propertyPendingCheck && bail.status === BailStatus.DRAFT) {
+  if (ownerPendingCheck && tenantPendingCheck && propertyPendingCheck && (bail.status === BailStatus.AWAITING_TENANT_FORM || bail.status === BailStatus.DRAFT)) {
     await prisma.bail.update({
       where: { id: bail.id },
       data: { status: BailStatus.PENDING_VALIDATION }

--- a/lib/utils/notifications.ts
+++ b/lib/utils/notifications.ts
@@ -151,25 +151,23 @@ export async function createNotificationForAllUsers(
     })),
   });
 
-  // Déclencher l'envoi d'email à chaque utilisateur via Inngest.
-  // On attend explicitement l'enqueue pour éviter les pertes sur les runtimes serverless.
-  const emailPromises = users
-    .filter((user) => user.email) // Seulement les utilisateurs avec un email
-    .map(async (user) => {
-      try {
-        await triggerNotificationEmail({
-          to: user.email!,
-          userName: user.name,
-          notificationMessage,
-          interfaceUrl,
-        });
-      } catch (error) {
-        console.error(`Erreur lors du déclenchement de l'email à ${user.email}:`, error);
-        // On continue même si l'email échoue
-      }
-    });
+  // Envoyer un seul email à tous les admins (1 appel Resend au lieu de N)
+  const adminEmails = users
+    .filter((user) => user.email)
+    .map((user) => user.email!);
 
-  await Promise.all(emailPromises);
+  if (adminEmails.length > 0) {
+    try {
+      await triggerNotificationEmail({
+        to: adminEmails,
+        userName: null,
+        notificationMessage,
+        interfaceUrl,
+      });
+    } catch (error) {
+      console.error("Erreur lors du déclenchement de l'email admin:", error);
+    }
+  }
 }
 
 /**
@@ -268,24 +266,22 @@ export async function createNotificationForUsers(
   const notificationMessage = getNotificationMessageText(type, metadata);
   const interfaceUrl = getNotificationInterfaceLink(targetType, targetId);
 
-  // Déclencher l'envoi d'email à chaque utilisateur via Inngest.
-  // On attend explicitement l'enqueue pour éviter les pertes sur les runtimes serverless.
-  const emailPromises = users
-    .filter((user) => user.email) // Seulement les utilisateurs avec un email
-    .map(async (user) => {
-      try {
-        await triggerNotificationEmail({
-          to: user.email!,
-          userName: user.name,
-          notificationMessage,
-          interfaceUrl,
-        });
-      } catch (error) {
-        console.error(`Erreur lors du déclenchement de l'email à ${user.email}:`, error);
-        // On continue même si l'email échoue
-      }
-    });
+  // Envoyer un seul email à tous les destinataires (1 appel Resend au lieu de N)
+  const recipientEmails = users
+    .filter((user) => user.email)
+    .map((user) => user.email!);
 
-  await Promise.all(emailPromises);
+  if (recipientEmails.length > 0) {
+    try {
+      await triggerNotificationEmail({
+        to: recipientEmails,
+        userName: null,
+        notificationMessage,
+        interfaceUrl,
+      });
+    } catch (error) {
+      console.error("Erreur lors du déclenchement de l'email:", error);
+    }
+  }
 }
 

--- a/lib/zod/lease.ts
+++ b/lib/zod/lease.ts
@@ -160,7 +160,7 @@ export const updateLeaseSchema = updateLeaseBaseSchema.superRefine((data, ctx) =
 
 export const transitionLeaseSchema = z.object({
   id: z.string().cuid("ID invalide"),
-  nextStatus: z.enum(["PENDING_VALIDATION", "READY_FOR_NOTARY", "CLIENT_CONTACTED", "SIGNED", "TERMINATED"]),
+  nextStatus: z.enum(["AWAITING_TENANT", "AWAITING_TENANT_FORM", "PENDING_VALIDATION", "READY_FOR_NOTARY", "CLIENT_CONTACTED", "SIGNED", "TERMINATED", "DESISTE", "CLASSE_SANS_SUITE"]),
 });
 
 export type CreateLeaseInput = z.infer<typeof createLeaseSchema>;

--- a/prisma/migrations/20260622101803_add_awaiting_tenant_form/migration.sql
+++ b/prisma/migrations/20260622101803_add_awaiting_tenant_form/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum
+ALTER TYPE "public"."BailStatus" ADD VALUE 'AWAITING_TENANT_FORM';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -83,6 +83,7 @@ enum BailFamille {
 enum BailStatus {
   DRAFT // brouillon, pas toute les données sont remplies
   AWAITING_TENANT // bail soumis et payé mais sans locataire renseigné
+  AWAITING_TENANT_FORM // bail soumis et payé, locataire existe mais n'a pas encore rempli son formulaire
   PENDING_VALIDATION // en attente de validation par bailnotarie si toute les donne sont remplies
   READY_FOR_NOTARY // prêt pour notaire
   CLIENT_CONTACTED // client contacté


### PR DESCRIPTION
## Résumé

- Harmonise les cartes propriétaire entre le dashboard et Mes dossiers via des composants partagés.
- Ajoute le statut `AWAITING_TENANT_FORM` pour distinguer un bail payé avec locataire renseigné mais formulaire locataire non complété.
- Met à jour les transitions serveur après soumission/paiement et après ajout de locataire.
- Sécurise la réutilisation d’un PaymentIntent Stripe déjà `succeeded` au lieu d’en recréer un.
- Ajuste les messages, badges, actions et boutons liés aux statuts propriétaire.

## Impact

- Interface propriétaire plus cohérente entre dashboard et Mes dossiers.
- Moins de risque de double paiement Stripe si un paiement a déjà réussi.
- Nouvelle valeur enum Prisma à migrer en base avant ou pendant le déploiement.

## Validation

- `git diff --check origin/main..origin/staging`
- `npm run build`
- `npx tsc --noEmit` après génération `.next`

## Note de déploiement

Cette PR ajoute la migration Prisma `20260622101803_add_awaiting_tenant_form`. La base doit accepter le nouveau statut `AWAITING_TENANT_FORM` avant que le code qui l’écrit soit utilisé en production.