### PR TITLE
fix(baux): dépôt de garantie meublé = 2 mois dans l'interface admin

### DIFF
--- a/components/leases/lease-form.tsx
+++ b/components/leases/lease-form.tsx
@@ -76,11 +76,15 @@ const leaseFormSchema = z
   .superRefine((data, ctx) => {
     const rentAmount = parseInt(data.rentAmount || "0", 10);
     const securityDeposit = parseInt(data.securityDeposit || "0", 10);
-    if (rentAmount > 0 && securityDeposit > rentAmount) {
+    // Bail meublé → max 2 mois de loyer hors charges ; bail nu → max 1 mois
+    const isMeubleBail =
+      data.bailType === "BAIL_MEUBLE_1_ANS" || data.bailType === "BAIL_MEUBLE_9_MOIS";
+    const maxDeposit = isMeubleBail ? rentAmount * 2 : rentAmount;
+    if (rentAmount > 0 && securityDeposit > maxDeposit) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         path: ["securityDeposit"],
-        message: `Le dépôt de garantie ne peut pas dépasser 1 mois de loyer hors charges (max ${rentAmount.toLocaleString("fr-FR")} €)`,
+        message: `Le dépôt de garantie ne peut pas dépasser ${isMeubleBail ? "2" : "1"} mois de loyer hors charges (max ${maxDeposit.toLocaleString("fr-FR")} €)`,
       });
     }
   });
@@ -94,17 +98,22 @@ export interface LeaseFormRef {
 const SecurityDepositValidation = ({ control }: { control: any }) => {
   const rentAmount = useWatch({ control, name: "rentAmount" });
   const securityDeposit = useWatch({ control, name: "securityDeposit" });
+  const bailType = useWatch({ control, name: "bailType" });
 
   const rentAmountNum = parseInt(rentAmount || "0", 10);
   const securityDepositNum = parseInt(securityDeposit || "0", 10);
-  const isExceeded = rentAmountNum > 0 && securityDepositNum > rentAmountNum;
+  // Bail meublé → max 2 mois de loyer hors charges ; bail nu → max 1 mois
+  const isMeubleBail =
+    bailType === "BAIL_MEUBLE_1_ANS" || bailType === "BAIL_MEUBLE_9_MOIS";
+  const maxDeposit = isMeubleBail ? rentAmountNum * 2 : rentAmountNum;
+  const isExceeded = rentAmountNum > 0 && securityDepositNum > maxDeposit;
 
   if (rentAmountNum <= 0) return null;
 
   return (
     <>
       <p className={`text-xs ${isExceeded ? "text-destructive font-medium" : "text-muted-foreground"}`}>
-        Maximum : {rentAmountNum.toLocaleString("fr-FR")} € (1 mois de loyer)
+        Maximum : {maxDeposit.toLocaleString("fr-FR")} € ({isMeubleBail ? "2 mois" : "1 mois"} de loyer)
       </p>
       {isExceeded && (
         <p className="text-sm text-destructive flex items-center gap-1">

--- a/lib/zod/lease.ts
+++ b/lib/zod/lease.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 
 // Helper pour valider le dépôt de garantie selon le type de bail
 function validateSecurityDeposit(
-  leaseType: string | undefined,
+  bailType: string | undefined,
   rentAmount: number | undefined,
   securityDeposit: number | undefined,
   ctx: z.RefinementCtx
@@ -11,14 +11,17 @@ function validateSecurityDeposit(
     return;
   }
 
-  // Bail nu → max 1 mois de loyer
-  const maxDeposit = rentAmount;
+  // Bail meublé → max 2 mois de loyer hors charges
+  // Bail nu → max 1 mois de loyer hors charges
+  const isMeubleBail =
+    bailType === "BAIL_MEUBLE_1_ANS" || bailType === "BAIL_MEUBLE_9_MOIS";
+  const maxDeposit = isMeubleBail ? rentAmount * 2 : rentAmount;
 
   if (securityDeposit > maxDeposit) {
     ctx.addIssue({
       code: z.ZodIssueCode.custom,
       path: ["securityDeposit"],
-      message: `Le dépôt de garantie ne peut pas dépasser 1 mois de loyer hors charges (max ${maxDeposit.toLocaleString("fr-FR")} €)`,
+      message: `Le dépôt de garantie ne peut pas dépasser ${isMeubleBail ? "2" : "1"} mois de loyer hors charges (max ${maxDeposit.toLocaleString("fr-FR")} €)`,
     });
   }
 }
@@ -82,7 +85,7 @@ const createLeaseBaseSchema = z.object({
 
 // Schéma de création avec validation du dépôt de garantie
 export const createLeaseSchema = createLeaseBaseSchema.superRefine((data, ctx) => {
-  validateSecurityDeposit(data.leaseType, data.rentAmount, data.securityDeposit, ctx);
+  validateSecurityDeposit(data.bailType, data.rentAmount, data.securityDeposit, ctx);
 });
 
 // Schéma de base pour la mise à jour - tous les champs sont optionnels
@@ -155,7 +158,7 @@ const updateLeaseBaseSchema = z.object({
 
 // Schéma de mise à jour avec validation du dépôt de garantie
 export const updateLeaseSchema = updateLeaseBaseSchema.superRefine((data, ctx) => {
-  validateSecurityDeposit(data.leaseType, data.rentAmount, data.securityDeposit, ctx);
+  validateSecurityDeposit(data.bailType, data.rentAmount, data.securityDeposit, ctx);
 });
 
 export const transitionLeaseSchema = z.object({


### PR DESCRIPTION
## Contexte

La validation du dépôt de garantie dans l'**interface admin** (création / modification de bail) était figée à **1 mois de loyer**, quel que soit le type de bail.

Or la règle légale distingue :

| Type de bail | Dépôt de garantie max |
|---|---|
| Bail nu | 1 mois de loyer hors charges |
| Bail meublé | **2 mois** de loyer hors charges |

Cette logique existait déjà côté **formulaire client** (`lib/zod/client.ts`) mais n'avait jamais été répliquée côté admin. Conséquence : un bail meublé avec 2 mois de dépôt (parfaitement légal) était **refusé à tort** avec le message « ne peut pas dépasser 1 mois ».

## Changements

Alignement de l'interface admin sur la logique éprouvée du formulaire client, en 3 points :

1. **`lib/zod/lease.ts`** — `validateSecurityDeposit` lit désormais `bailType` (au lieu de `leaseType`, qui n'était même pas utilisé) et applique le plafond ×2 pour les meublés. Appliqué aux schémas **create** et **update**.
2. **`components/leases/lease-form.tsx` (`superRefine`)** — plafond dynamique (×2 meublé / ×1 nu) + message d'erreur adapté.
3. **`components/leases/lease-form.tsx` (`SecurityDepositValidation`)** — l'affichage du maximum suit désormais `bailType` (« 2 mois » / « 1 mois »).

## Détermination du type

`isMeubleBail = bailType === "BAIL_MEUBLE_1_ANS" || bailType === "BAIL_MEUBLE_9_MOIS"` → `maxDeposit = isMeubleBail ? rentAmount * 2 : rentAmount`.

## Tests

Typecheck non exécutable dans l'environnement (`node_modules` absent) ; les changements sont minimes et reproduisent exactement le pattern déjà en production côté `client.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HG9s8mMHcCSDVTdyXDAfeY

---
_Generated by [Claude Code](https://claude.ai/code/session_01HG9s8mMHcCSDVTdyXDAfeY)_